### PR TITLE
feat: useBoolean 공통 컴포넌트 구현

### DIFF
--- a/src/hooks/useBoolean.ts
+++ b/src/hooks/useBoolean.ts
@@ -1,0 +1,25 @@
+import { useCallback, useState } from 'react';
+
+const useBoolean = (initialValue: boolean = false) => {
+  const [value, setValue] = useState(initialValue);
+
+  const toggle = useCallback(() => {
+    setValue((prev) => !prev);
+  }, []);
+
+  const setTrue = useCallback(() => {
+    setValue(true);
+  }, []);
+
+  const setFalse = useCallback(() => {
+    setValue(false);
+  }, []);
+
+  const changeValue = useCallback((newValue: boolean) => {
+    setValue(newValue);
+  }, []);
+
+  return { value, toggle, setTrue, setFalse, changeValue };
+};
+
+export default useBoolean;


### PR DESCRIPTION
## PR요약

<!---- PR제목은 [기능]: '제목"으로 작성해주세요 ex) Feat : 로그인/회원가입기능 폼구현. -->
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

<!---- Resolves: #(Isuue Number) -->

boolean값을 관리하는 공통 custom Hook을 구현했습니다.

### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 스타일 관련
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
1. changeValue
setValue를 넘겨주는것이 아닌 changeValue함수를 반환하는 이유는
React의 기본 상태 설정 함수이기 때문에, 이를 그대로 노출하면 내부 상태 변경 방식이 외부에 너무 노출될 수 있어서,  
추상화 계층을 한 번 둬서 **의도한 사용 방식만 제공**하는 게 더 안전하다고 생각했습니다.

2. useCallback
굳이 사용하지 않아도 되긴 하지만
이 훅에서 반환하는 `toggle`, `setTrue`, `setFalse` 같은 함수들을 외부에서 memoized 컴포넌트나 의존성 배열 안에서 사용할 수도 있기 때문에, useCallback으로 감싸줌으로써 참조의 안정성을 확보해주는 겁니다.


### 구현결과(사진첨부 선택)
사용 예시
```
const {value, onToggle, onFalse, onTrue, changeBooleanValue} = useBoolean() // default:  false
const {...} = useBoolean(true) // 초기값 true로 설정

```
