### PR TITLE
Feat: GridCard 컴포넌트 구현

### DIFF
--- a/src/components/common/Card/GridCard.stories.tsx
+++ b/src/components/common/Card/GridCard.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import GridCard from './GridCard';
+import { GridCardProps } from '@/components/common/Card/type';
+
+const meta: Meta<typeof GridCard> = {
+  title: 'Common/GridCard',
+  component: GridCard,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof GridCard>;
+
+export const ShortContent: Story = {
+  args: {
+    pageId: '1',
+    tag: (
+      <span className="bg-write-success rounded px-2 py-1 text-xs">New</span>
+    ),
+    imageSrc:
+      'https://inabooth.io/_next/image?url=https%3A%2F%2Fd19bi7owzxc0m2.cloudfront.net%2Fprod%2Fcharacter_files%2FRwH7fLwSHwA4_e2s354f2.webp&w=3840&q=75',
+    imageAlt: '테스트 이미지',
+    title: '짧은 제목',
+    genre: '판타지',
+    description: '짧은 설명이 들어가는 description 영역입니다.',
+  } as GridCardProps,
+};
+
+export const LongContent: Story = {
+  args: {
+    pageId: '3',
+    tag: <span className="rounded bg-yellow-200 px-2 py-1 text-xs">Top</span>,
+    imageSrc:
+      'https://inabooth.io/_next/image?url=https%3A%2F%2Fd19bi7owzxc0m2.cloudfront.net%2Fprod%2Fcharacter_files%2FRwH7fLwSHwA4_e2s354f2.webp&w=3840&q=75',
+    imageAlt: '긴 설명 이미지',
+    title: '제목이 최대 글자 수를 초과할 경우입니다.',
+    genre: '판타지',
+    description:
+      '이 설명은 지정된 최대 줄 수를 초과하기 때문에 초과된 설명 description을 자르고 line-clamp 스타일을 적용하여 화면에 줄임표(...)로 표시되어야 하는지 확인하기 위한 테스트용 문장입니다.',
+  } as GridCardProps,
+};
+
+export const SkeletonUI: Story = {
+  args: {
+    pageId: '1',
+    tag: undefined,
+    imageSrc: '',
+    imageAlt: '',
+    title: '',
+    genre: '',
+    description: '',
+  } as GridCardProps,
+};

--- a/src/components/common/Card/GridCard.stories.tsx
+++ b/src/components/common/Card/GridCard.stories.tsx
@@ -18,12 +18,15 @@ export const ShortContent: Story = {
     tag: (
       <span className="bg-write-success rounded px-2 py-1 text-xs">New</span>
     ),
-    imageSrc:
-      'https://inabooth.io/_next/image?url=https%3A%2F%2Fd19bi7owzxc0m2.cloudfront.net%2Fprod%2Fcharacter_files%2FRwH7fLwSHwA4_e2s354f2.webp&w=3840&q=75',
-    imageAlt: '테스트 이미지',
-    title: '짧은 제목',
-    genre: '판타지',
-    description: '짧은 설명이 들어가는 description 영역입니다.',
+    image: {
+      src: 'https://inabooth.io/_next/image?url=https%3A%2F%2Fd19bi7owzxc0m2.cloudfront.net%2Fprod%2Fcharacter_files%2FRwH7fLwSHwA4_e2s354f2.webp&w=3840&q=75',
+      alt: '테스트 이미지',
+    },
+    textContent: {
+      title: '짧은 제목',
+      genre: '판타지',
+      description: '짧은 설명이 들어가는 description 영역입니다.',
+    },
     isCardDataLoading: false,
   } as GridCardProps,
 };
@@ -32,13 +35,16 @@ export const LongContent: Story = {
   args: {
     pageId: '3',
     tag: <span className="rounded bg-yellow-200 px-2 py-1 text-xs">Top</span>,
-    imageSrc:
-      'https://inabooth.io/_next/image?url=https%3A%2F%2Fd19bi7owzxc0m2.cloudfront.net%2Fprod%2Fcharacter_files%2FRwH7fLwSHwA4_e2s354f2.webp&w=3840&q=75',
-    imageAlt: '긴 설명 이미지',
-    title: '제목이 최대 글자 수를 초과할 경우입니다.',
-    genre: '판타지',
-    description:
-      '이 설명은 지정된 최대 줄 수를 초과하기 때문에 초과된 설명 description을 자르고 line-clamp 스타일을 적용하여 화면에 줄임표(...)로 표시되어야 하는지 확인하기 위한 테스트용 문장입니다.',
+    image: {
+      src: 'https://inabooth.io/_next/image?url=https%3A%2F%2Fd19bi7owzxc0m2.cloudfront.net%2Fprod%2Fcharacter_files%2FRwH7fLwSHwA4_e2s354f2.webp&w=3840&q=75',
+      alt: '긴 설명 이미지',
+    },
+    textContent: {
+      title: '제목이 최대 글자 수를 초과할 경우입니다.',
+      genre: '판타지',
+      description:
+        '이 설명은 지정된 최대 줄 수를 초과하기 때문에 초과된 설명 description을 자르고 line-clamp 스타일을 적용하여 화면에 줄임표(...)로 표시되어야 하는지 확인하기 위한 테스트용 문장입니다.',
+    },
     isCardDataLoading: false,
   } as GridCardProps,
 };
@@ -47,11 +53,15 @@ export const SkeletonUI: Story = {
   args: {
     pageId: '1',
     tag: undefined,
-    imageSrc: '',
-    imageAlt: '',
-    title: '',
-    genre: '',
-    description: '',
+    image: {
+      src: '',
+      alt: '',
+    },
+    textContent: {
+      title: '',
+      genre: '',
+      description: '',
+    },
     isCardDataLoading: true,
   } as GridCardProps,
 };

--- a/src/components/common/Card/GridCard.stories.tsx
+++ b/src/components/common/Card/GridCard.stories.tsx
@@ -24,6 +24,7 @@ export const ShortContent: Story = {
     title: '짧은 제목',
     genre: '판타지',
     description: '짧은 설명이 들어가는 description 영역입니다.',
+    isCardDataLoading: false,
   } as GridCardProps,
 };
 
@@ -38,6 +39,7 @@ export const LongContent: Story = {
     genre: '판타지',
     description:
       '이 설명은 지정된 최대 줄 수를 초과하기 때문에 초과된 설명 description을 자르고 line-clamp 스타일을 적용하여 화면에 줄임표(...)로 표시되어야 하는지 확인하기 위한 테스트용 문장입니다.',
+    isCardDataLoading: false,
   } as GridCardProps,
 };
 
@@ -50,5 +52,6 @@ export const SkeletonUI: Story = {
     title: '',
     genre: '',
     description: '',
+    isCardDataLoading: true,
   } as GridCardProps,
 };

--- a/src/components/common/Card/GridCard.tsx
+++ b/src/components/common/Card/GridCard.tsx
@@ -58,10 +58,10 @@ const GridCard = ({
           {description ? (
             <p className="line-clamp-3 text-sm text-gray-600">{description}</p>
           ) : (
-            <div className="space-y-1">
-              <div className="h-3.5 w-full animate-pulse rounded bg-gray-300" />
-              <div className="h-3.5 w-5/6 animate-pulse rounded bg-gray-300" />
-              <div className="h-3.5 w-2/3 animate-pulse rounded bg-gray-300" />
+            <div className="animate-pulse space-y-1">
+              <div className="h-3.5 w-full rounded bg-gray-300" />
+              <div className="h-3.5 w-5/6 rounded bg-gray-300" />
+              <div className="h-3.5 w-2/3 rounded bg-gray-300" />
             </div>
           )}
         </div>

--- a/src/components/common/Card/GridCard.tsx
+++ b/src/components/common/Card/GridCard.tsx
@@ -19,7 +19,6 @@ const GridCard = ({
   return (
     <article className="h-80 w-90 rounded-2xl p-2 hover:bg-gray-100">
       <Link
-        key={pageId}
         href={`/details/${pageId}`}
         className="flex h-full flex-col"
         aria-label={`${title ? `${title}상세 페이지로 이동` : '데이터를 불러오는 중입니다'}`}

--- a/src/components/common/Card/GridCard.tsx
+++ b/src/components/common/Card/GridCard.tsx
@@ -12,6 +12,7 @@ const GridCard = ({
   title,
   genre,
   description,
+  isCardDataLoading,
 }: GridCardProps) => {
   const { isImageLoaded, isImageLoadError, onLoad, onError } =
     useImageLoadStatus();
@@ -25,7 +26,7 @@ const GridCard = ({
       >
         <figure className="relative h-48">
           {tag && <div className="absolute top-1 right-2 z-10">{tag}</div>}
-          {!isImageLoaded || isImageLoadError ? (
+          {!isImageLoaded || isImageLoadError || isCardDataLoading ? (
             <div className="absolute h-full w-full animate-pulse rounded-xl bg-gray-300" />
           ) : null}
           {imageSrc && (
@@ -42,19 +43,19 @@ const GridCard = ({
         </figure>
         <div className="mt-2 px-2 py-1">
           <div className="mb-1 flex w-78 items-center gap-2.5">
-            {title ? (
+            {!isCardDataLoading ? (
               <h2 className="truncate text-xl font-semibold">{title}</h2>
             ) : (
               <div className="h-6 w-40 animate-pulse rounded bg-gray-300" />
             )}
             <div className="h-5 border border-r-1" />
-            {genre ? (
+            {!isCardDataLoading ? (
               <p className="whitespace-nowrap">{genre}</p>
             ) : (
               <div className="h-5 w-15 animate-pulse rounded bg-gray-300" />
             )}
           </div>
-          {description ? (
+          {!isCardDataLoading ? (
             <p className="line-clamp-3 text-sm text-gray-600">{description}</p>
           ) : (
             <div className="animate-pulse space-y-1">

--- a/src/components/common/Card/GridCard.tsx
+++ b/src/components/common/Card/GridCard.tsx
@@ -1,0 +1,73 @@
+'use client';
+import Link from 'next/link';
+import { GridCardProps } from '@/components/common/Card/type';
+import Image from 'next/image';
+import useImageLoadStatus from '@/hooks/useImageLoadStatus';
+
+const GridCard = ({
+  pageId,
+  tag,
+  imageSrc,
+  imageAlt,
+  title,
+  genre,
+  description,
+}: GridCardProps) => {
+  const { isImageLoaded, isImageLoadError, onLoad, onError } =
+    useImageLoadStatus();
+
+  return (
+    <article className="h-80 w-90 rounded-2xl p-2 hover:bg-gray-100">
+      <Link
+        key={pageId}
+        href={`/details/${pageId}`}
+        className="flex h-full flex-col"
+        aria-label={`${title ? `${title}상세 페이지로 이동` : '데이터를 불러오는 중입니다'}`}
+      >
+        <figure className="relative h-48">
+          {tag && <div className="absolute top-1 right-2 z-10">{tag}</div>}
+          {!isImageLoaded || isImageLoadError ? (
+            <div className="absolute h-full w-full animate-pulse rounded-xl bg-gray-300" />
+          ) : null}
+          {imageSrc && (
+            <Image
+              src={imageSrc}
+              alt={imageAlt ? imageAlt : '이미지를 불러올 수 없습니다'}
+              onLoad={onLoad}
+              onError={onError}
+              fill
+              className={`rounded-xl object-cover ${isImageLoaded ? 'opacity-100' : 'opacity-0'}`}
+              unoptimized // next/image의 이미지 도메인 등록 문제 해결 후 삭제
+            />
+          )}
+        </figure>
+        <div className="mt-2 px-2 py-1">
+          <div className="mb-1 flex w-78 items-center gap-2.5">
+            {title ? (
+              <h2 className="truncate text-xl font-semibold">{title}</h2>
+            ) : (
+              <div className="h-6 w-40 animate-pulse rounded bg-gray-300" />
+            )}
+            <div className="h-5 border border-r-1" />
+            {genre ? (
+              <p className="whitespace-nowrap">{genre}</p>
+            ) : (
+              <div className="h-5 w-15 animate-pulse rounded bg-gray-300" />
+            )}
+          </div>
+          {description ? (
+            <p className="line-clamp-3 text-sm text-gray-600">{description}</p>
+          ) : (
+            <div className="space-y-1">
+              <div className="h-3.5 w-full animate-pulse rounded bg-gray-300" />
+              <div className="h-3.5 w-5/6 animate-pulse rounded bg-gray-300" />
+              <div className="h-3.5 w-2/3 animate-pulse rounded bg-gray-300" />
+            </div>
+          )}
+        </div>
+      </Link>
+    </article>
+  );
+};
+
+export default GridCard;

--- a/src/components/common/Card/GridCard.tsx
+++ b/src/components/common/Card/GridCard.tsx
@@ -7,11 +7,8 @@ import useImageLoadStatus from '@/hooks/useImageLoadStatus';
 const GridCard = ({
   pageId,
   tag,
-  imageSrc,
-  imageAlt,
-  title,
-  genre,
-  description,
+  image,
+  textContent,
   isCardDataLoading,
 }: GridCardProps) => {
   const { isImageLoaded, isImageLoadError, onLoad, onError } =
@@ -22,17 +19,17 @@ const GridCard = ({
       <Link
         href={`/details/${pageId}`}
         className="flex h-full flex-col"
-        aria-label={`${title ? `${title}상세 페이지로 이동` : '데이터를 불러오는 중입니다'}`}
+        aria-label={`${textContent.title ? `${textContent.title}상세 페이지로 이동` : '데이터를 불러오는 중입니다'}`}
       >
         <figure className="relative h-48">
           {tag && <div className="absolute top-1 right-2 z-10">{tag}</div>}
           {!isImageLoaded || isImageLoadError || isCardDataLoading ? (
             <div className="absolute h-full w-full animate-pulse rounded-xl bg-gray-300" />
           ) : null}
-          {imageSrc && (
+          {image.src && image.alt && !isCardDataLoading && (
             <Image
-              src={imageSrc}
-              alt={imageAlt ? imageAlt : '이미지를 불러올 수 없습니다'}
+              src={image.src}
+              alt={image.alt ? image.alt : '이미지를 불러올 수 없습니다'}
               onLoad={onLoad}
               onError={onError}
               fill
@@ -44,19 +41,23 @@ const GridCard = ({
         <div className="mt-2 px-2 py-1">
           <div className="mb-1 flex w-78 items-center gap-2.5">
             {!isCardDataLoading ? (
-              <h2 className="truncate text-xl font-semibold">{title}</h2>
+              <h2 className="truncate text-xl font-semibold">
+                {textContent.title}
+              </h2>
             ) : (
               <div className="h-6 w-40 animate-pulse rounded bg-gray-300" />
             )}
             <div className="h-5 border border-r-1" />
             {!isCardDataLoading ? (
-              <p className="whitespace-nowrap">{genre}</p>
+              <p className="whitespace-nowrap">{textContent.genre}</p>
             ) : (
               <div className="h-5 w-15 animate-pulse rounded bg-gray-300" />
             )}
           </div>
           {!isCardDataLoading ? (
-            <p className="line-clamp-3 text-sm text-gray-600">{description}</p>
+            <p className="line-clamp-3 text-sm text-gray-600">
+              {textContent.description}
+            </p>
           ) : (
             <div className="animate-pulse space-y-1">
               <div className="h-3.5 w-full rounded bg-gray-300" />

--- a/src/components/common/Card/type.ts
+++ b/src/components/common/Card/type.ts
@@ -1,0 +1,11 @@
+import { ReactNode } from 'react';
+
+export interface GridCardProps {
+  pageId: string | null;
+  tag?: ReactNode;
+  imageSrc: string | null;
+  imageAlt: string | null;
+  title: string | null;
+  genre: string | null;
+  description: string | null;
+}

--- a/src/components/common/Card/type.ts
+++ b/src/components/common/Card/type.ts
@@ -1,12 +1,23 @@
 import { ReactNode } from 'react';
 
+interface BaseTextContentProps {
+  title: string | null;
+  genre: string | null;
+}
+
+interface GridCardtextContentProps extends BaseTextContentProps {
+  description: string | null;
+}
+
+interface ImageProps {
+  src: string | null;
+  alt: string | null;
+}
+
 export interface GridCardProps {
   pageId: string | null;
   tag?: ReactNode;
-  imageSrc: string | null;
-  imageAlt: string | null;
-  title: string | null;
-  genre: string | null;
-  description: string | null;
+  image: ImageProps;
+  textContent: GridCardtextContentProps;
   isCardDataLoading: boolean;
 }

--- a/src/components/common/Card/type.ts
+++ b/src/components/common/Card/type.ts
@@ -8,4 +8,5 @@ export interface GridCardProps {
   title: string | null;
   genre: string | null;
   description: string | null;
+  isCardDataLoading: boolean;
 }

--- a/src/hooks/useImageLoadStatus.ts
+++ b/src/hooks/useImageLoadStatus.ts
@@ -1,0 +1,16 @@
+'use client';
+import { useState } from 'react';
+
+const useImageLoadStatus = () => {
+  const [isImageLoaded, setIsImageLoaded] = useState(false);
+  const [isImageLoadError, setIsImageLoadError] = useState(false);
+
+  return {
+    isImageLoaded,
+    isImageLoadError,
+    onLoad: () => setIsImageLoaded(true),
+    onError: () => setIsImageLoadError(true),
+  };
+};
+
+export default useImageLoadStatus;


### PR DESCRIPTION
GridCard UI 컴포넌트를 구현했습니다.
이미지와 스켈레톤 UI 분기처리를 위하여 커스텀 훅을 만들었고, UI 테스트를 위한 스토리북 파일을 추가하였습니다.

## PR요약

<!---- PR제목은 [기능]: '제목"으로 작성해주세요 ex) Feat : 로그인/회원가입기능 폼구현. -->
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

<!---- Resolves: #(Isuue Number) -->

### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 스타일 관련
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항

각 페이지마다 사용되는 카드 UI에 차이가 존재하여 Card 컴포넌트를 둘 이상으로 나누게 되었습니다.
`GridCard`라는 컴포넌트 네이밍이 의미가 명확하지 않다고 느끼실 수 있는데 아래의 타임 라인에 어떤 고민을 거쳐
Card의 네이밍을 결정하였는지 정리해두었습니다.
[ [노션] Card 컴포넌트 - 개발 Timeline ](https://www.google.com)

최상위 태그를 article 태그로 감싸주었고, 이미지를 fiture태그로 감싸고,
각 타이틀에 h2태그를 사용하여 의미론적인 HTML 작성에 신경썼습니다.

### next/image 렌더링 테스트
API를 통해 받아오는 이미지 도메인 주소를 알 수 없는 상태이기 때문에 next/image의 Image태그에 `unoptimized` 속성을 사용하였는데,
이미지를 확인하는데로 next.config.js에 도메인 주소를 등록한 뒤에 `unoptimized` 속성을 제거하는 등 수정이 필요합니다.
(현재 unoptimized 속성으로 인해 next/image의 최적화 기능이 동작하지 않습니다.)

### 스켈레톤 UI 분기 처리에 상태를 사용해야 했는가?
state를 사용하여 스켈레톤 UI가 조건부로 출력되도록 설정하였는데, state를 사용하지 않고 props로 전달받는 imageUrl을 사용해도
유사한 분기처리가 가능 했습니다. 이 2가지 방식에는 각각 장단점이 있었는데 쉽게 정리하면
1. state를 사용하면 사용자 경험에 유리하고, 
2. state를 제거하면 코드가 단순해지고 성능면에서(SSR) 이점을 가져갈 수 있습니다.

**제 결정은 state를 사용하는 것**이었고, 이에 대한 고민도 타임 라인에 함께 기재해두었습니다.
추후에 실제 데이터를 바인딩했을 때의 로드 속도 등을 테스트해보고 더 나은 방향을 선택해야 할 것 같습니다.
[ [노션] Card 컴포넌트 - 개발 Timeline ](https://www.google.com)

### 모임 상세 페이지(동적 라우트)로 이동하는 Link href
```
href={`/details/${pageId}`}
```
상세 페이지에 대한 동적 라우트 주소가 확정되지 않아 임의로 `details/페이지id`의 주소로 연결되도록 설정하였습니다.
실제 동적 라우트 주소가 달라진다면 수정이 필요합니다.

### 스토리북 적용
1. 제목(title)과 설명(description)이 화면에 표시되는 최대 글자수를 초과하지 않는 경우
2. 제목(title)과 설명(description)이 화면에 표시되는 최대 글자수를 초과하는 경우
(초과한 텍스트는 잘리고 줄임표(...)로 표시됩니다)
3. props로 nullish한 값이 들어와 스켈레톤 UI가 표시되는 경우
위 3가지 케이스에 대한 스토리를 제작했습니다.

(Badge 컴포넌트는 구현되지 않아서 임의의 디자인으로 테스트 진행했습니다.)
![screencapture-localhost-6006-2025-05-20-18_17_19](https://github.com/user-attachments/assets/6d8a6701-039e-45ce-ba3e-0de6db9624b6)

![screencapture-localhost-6006-2025-05-20-18_17_41](https://github.com/user-attachments/assets/d788185a-ca25-41cf-bdc3-ac2d318afd09)


### 추가 develop & 의논사항
현재 컴포넌트가 받아오는 props 중에 article이나 image태그의 스타일을 변경할 수 있는 css(className)이 존재하지 않는데,
실제 페이지 상에서 카드 디자인을 변경해야 하는 상황이 발생하는지 확인이 필요할 것 같습니다.

