### PR TITLE
Feat: layout auths 경로만 제외되게 변경

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from 'next';
 import '@/styles/globals.css';
 import QueryProviders from '@/providers/queryProviders';
 import { GNB } from '@/components/layout/GNB/GNB';
+import LayoutWrapper from '@/components/layout/LayoutWrapper';
 
 const pretendard = localFont({
   src: '../fonts/PretendardVariable.woff2',
@@ -29,14 +30,14 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body
-        className={`${pretendard.variable} ${hanuman.variable} antialiased`}
+        className={`flex min-h-screen flex-col ${pretendard.variable} ${hanuman.variable} antialiased`}
       >
         <QueryProviders>
           <header>
             <GNB />
           </header>
-          <main className="min-h-screen w-full bg-gray-100 p-4 pt-15">
-            {children}
+          <main className="flex-1 bg-gray-100">
+            <LayoutWrapper>{children}</LayoutWrapper>
           </main>
         </QueryProviders>
       </body>

--- a/src/components/layout/LayoutWrapper.tsx
+++ b/src/components/layout/LayoutWrapper.tsx
@@ -10,7 +10,7 @@ export default function LayoutWrapper({
 }) {
   const pathname = usePathname();
   const isAuths = pathname.startsWith('/auths');
-  const basicStyle = 'mx-auto w-full max-w-[1200px] px-4 pt-20 min-h-lvh';
+  const basicStyle = 'mx-auto w-full max-w-300 px-4 pt-20 min-h-lvh';
   return (
     <div className={`${basicStyle} ${isAuths ? null : 'bg-gray-50'}`}>
       {children}

--- a/src/components/layout/LayoutWrapper.tsx
+++ b/src/components/layout/LayoutWrapper.tsx
@@ -1,0 +1,19 @@
+// src/components/LayoutWrapper.tsx
+'use client';
+
+import { usePathname } from 'next/navigation';
+
+export default function LayoutWrapper({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const pathname = usePathname();
+  const isAuths = pathname.startsWith('/auths');
+  const basicStyle = 'mx-auto w-full max-w-[1200px] px-4 pt-20 min-h-lvh';
+  return (
+    <div className={`${basicStyle} ${isAuths ? null : 'bg-gray-50'}`}>
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## PR요약
auths 경로만 layout이 달라서 경로에 /auths가 포함된 경로만 스타일 적용 제외하였습니다.



### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 스타일 관련
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트



### 변경 사항
![login](https://github.com/user-attachments/assets/b131be7b-926e-4800-87f1-b086a9f1124e)
![others](https://github.com/user-attachments/assets/cba2d707-7f11-457a-9202-1806f833b1fd)
figma를 보다가 auths 페이지만 스타일이 다른걸 발견해서 적용하게 되었습니다.



### 구현결과(사진첨부 선택)
![code](https://github.com/user-attachments/assets/8c354170-9e8d-4722-9624-084b28376df7)
