### PR TITLE
Chore: next/image 사용을 위하여 이미지 도메인 주소 추가

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -20,6 +20,9 @@ const nextConfig: NextConfig = {
       },
     },
   },
+  images: {
+    domains: ['sprint-fe-project.s3.ap-northeast-2.amazonaws.com'],
+  },
 };
 
 export default nextConfig;

--- a/src/components/common/Card/GridCard.tsx
+++ b/src/components/common/Card/GridCard.tsx
@@ -34,7 +34,6 @@ const GridCard = ({
               onError={onError}
               fill
               className={`rounded-xl object-cover ${isImageLoaded ? 'opacity-100' : 'opacity-0'}`}
-              unoptimized // next/image의 이미지 도메인 등록 문제 해결 후 삭제
             />
           )}
         </figure>

--- a/src/components/common/Card/ListCard.tsx
+++ b/src/components/common/Card/ListCard.tsx
@@ -52,7 +52,6 @@ const ListCard = ({
             onError={onError}
             fill
             className={`rounded-3xl object-cover ${isImageLoaded ? 'opacity-100' : 'opacity-0'}`}
-            unoptimized // next/image의 이미지 도메인 등록 문제 해결 후 삭제
           />
         )}
       </figure>


### PR DESCRIPTION
## PR요약
<!---- PR제목은 [기능]: '제목"으로 작성해주세요 ex) Feat : 로그인/회원가입기능 폼구현. -->
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->



### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 스타일 관련
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트



### 변경 사항
<!---- ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. -->
`next/image`의  `<Image>` 태그를 사용하기 위해 `next.config.ts`에 이미지 도메인을 추가하였습니다.
```
images: {
  domains: ['sprint-fe-project.s3.ap-northeast-2.amazonaws.com'],
},
```
기존에 도메인이 적용되지 않아서 임시로 적용되어 있던, `<Image>`의 `unoptimized` 속성들을 제거하였습니다.
