### PR TITLE
Fix: 글자 크기 드롭다운 컨테이너가 화면 위치에 고정되는 문제 수정

### DIFF
--- a/src/components/common/TextEditor/EditorToolbar.tsx
+++ b/src/components/common/TextEditor/EditorToolbar.tsx
@@ -148,12 +148,12 @@ const EditorToolbar = ({ editor }: EditorToolbarProps) => {
   };
 
   return (
-    <div className="flex flex-wrap items-center gap-x-5 gap-y-4 border-b border-b-gray-300 p-2 pt-0 sm:gap-7">
+    <div className="relative flex flex-wrap items-center gap-x-5 gap-y-4 border-b border-b-gray-300 p-2 pt-0 sm:gap-7">
       <Dropdown
         trigger={<button onClick={toggle}>{currentFontSize}</button>}
         isOpen={value}
       >
-        <Dropdown.Container className="fixed z-10 shadow-md">
+        <Dropdown.Container className="absolute z-10 shadow-md">
           {FONT_SIZE_OPTIONS.map((size) => (
             <Dropdown.Content
               key={size}


### PR DESCRIPTION
## PR요약
<!---- PR제목은 [기능]: '제목"으로 작성해주세요 ex) Feat : 로그인/회원가입기능 폼구현. -->
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->


### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 스타일 관련
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트



### 변경 사항
<!---- ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. -->
![툴바_드롭다운_fixed](https://github.com/user-attachments/assets/6801e909-be47-4eff-a9c8-b0c4c500714a)
![툴바_드롭다운_fixed_2](https://github.com/user-attachments/assets/996801c8-7524-4c8b-b425-7df4a890d86f)


기존 `DropDown` 컨테이너는 `position: fixed` 로 지정되어 있었습니다.
그로인해 위 이미지와 같이 드롭다운 컨테이너가 화면의 특정 위치에 고정되어, 스크롤이 움직이면 컨테이너의 위치도 이동되는 버그가 있습니다.

툴바 메뉴에 `position: relative` 를, 드롭다운 컨테이너에 `fixed` -> `position: absolute` 를 적용하였습니다.
드롭다운의 위치가 뷰포트 기준이 아닌 전체 메뉴 영역을 기준으로 설정되도록 하여 문제를 해결하였습니다.
