### PR TITLE
Fix: 모임 상세 페이지 실제 URL과 Card컴포넌트에 적용된 Link href가 다른 문제 수정

### DIFF
--- a/src/components/common/Card/GridCard.tsx
+++ b/src/components/common/Card/GridCard.tsx
@@ -17,7 +17,7 @@ const GridCard = ({
   return (
     <article className="h-80 w-90 rounded-2xl p-2 hover:bg-gray-100">
       <Link
-        href={`/details/${pageId}`}
+        href={`social/detail/${pageId}`}
         className="flex h-full flex-col"
         aria-label={`${textContent.title ? `${textContent.title}상세 페이지로 이동` : '데이터를 불러오는 중입니다'}`}
       >

--- a/src/components/common/Card/ListCard.tsx
+++ b/src/components/common/Card/ListCard.tsx
@@ -64,7 +64,7 @@ const ListCard = ({
         <div className="flex flex-row items-center gap-2">
           {!isCardDataLoading ? (
             <Link
-              href={`/details/${pageId}`}
+              href={`social/detail/${pageId}`}
               className="flex h-full max-w-66 flex-col sm:max-w-180"
               aria-label={`${textContent.title ? `${textContent.title}상세 페이지로 이동` : '데이터를 불러오는 중입니다'}`}
             >


### PR DESCRIPTION
## PR요약
<!---- PR제목은 [기능]: '제목"으로 작성해주세요 ex) Feat : 로그인/회원가입기능 폼구현. -->
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 스타일 관련
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트



### 변경 사항
`GridCard`와 `ListCard`를 클릭했을 때 페이지 전환되는 주소가 실제 상세 페이지 주소와 동일하게 변경되었습니다.
- 기존 : `href={`/details/${pageId}`}`
- 변경 후 : `href={`social/detail/${pageId}`}`





