### PR TITLE
Feat: 스토리 아이디를 통한 컨텐츠 병합 함수 추가

### DIFF
--- a/src/api/stories/api.ts
+++ b/src/api/stories/api.ts
@@ -92,3 +92,48 @@ export const getContents = async ({
   }
   return { data, count: count ?? 0 };
 };
+
+export const updateContentMerge = async (storyId: string): Promise<void> => {
+  try {
+    const { data: story, error } = await instanceBaaS
+      .from('Stories')
+      .select('approved_count')
+      .eq('story_id', storyId)
+      .single();
+
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    const { data: content, error: contentsError } = await instanceBaaS
+      .from('Contents')
+      .select('content_id')
+      .eq('story_id', storyId)
+      .single();
+    if (contentsError) {
+      throw new Error(contentsError.message);
+    }
+
+    const { data: content_approve_count, error: contentApproveError } =
+      await instanceBaaS
+        .from('ContentApproval')
+        .select('*', { count: 'exact' })
+        .eq('content_id', content.content_id);
+    if (contentApproveError) {
+      throw new Error(contentApproveError.message);
+    }
+
+    if (content_approve_count.length >= story.approved_count) {
+      await instanceBaaS
+        .from('Contents')
+        .update({
+          status: 'MERGED',
+        })
+        .eq('story_id', storyId);
+    } else {
+      throw new Error('스토리 승인 기준 미달');
+    }
+  } catch (error) {
+    throw new Error(error as string);
+  }
+};


### PR DESCRIPTION
## 이슈[154]

## PR요약
<!---- PR제목은 [기능]: '제목"으로 작성해주세요 ex) Feat : 로그인/회원가입기능 폼구현. -->
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 스토리 아이디를 통한 컨텐츠 병합 함수 추가


### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 스타일 관련
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트



### 변경 사항
<!---- ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. -->
- 아무 인자없이 병합되게 하는 게 구현의도랑은 맞지않는 것 같아서 스토리 아이디를 인자로 받습니다.
1. 스토리 아이디를 통해서 해당 스토리의 approved_count 를 조회
2. 컨텐츠에서 해당 스토리의 컨텐츠를 조회
3. 컨텐츠 승인 테이블에서 해당 컨텐츠 아이디를 가진 필드 수를 조회
4. approved_count 와 컨텐츠 승인의 필드 수를 비교
5. 조건 성립시 해당 컨텐츠 상태를 MERGED로 변경

위와 같은 순서의 구조입니다.



### 구현결과(사진첨부 선택)
(내용)
