### PR TITLE
Feat: 마이페이지 MySocialList 구현

### DIFF
--- a/src/api/mypage/api.ts
+++ b/src/api/mypage/api.ts
@@ -1,0 +1,45 @@
+import { API_PATH } from '@/constants/apiPath';
+import {
+  leaveJoinSocialRequest,
+  GetJoinedSocialListParams,
+  JoinedSocialResponse,
+} from './type';
+import instance from '@/api/instance';
+import { getFilterParams } from '@/utils/getFilterParams';
+
+export const getJoinedSocialList = async ({
+  limit = 12,
+  offset = 0,
+  ...restParams
+}: GetJoinedSocialListParams) => {
+  try {
+    const response = await instance.get<JoinedSocialResponse[]>(
+      `${API_PATH.SOCIAL}/joined?${getFilterParams({
+        limit,
+        offset,
+        ...restParams,
+      })}`
+    );
+    return response.data;
+  } catch (error) {
+    throw error;
+  }
+};
+
+export const leaveJoinSocial = async ({ id }: leaveJoinSocialRequest) => {
+  try {
+    const response = await instance.delete(API_PATH.SOCIAL + `/${id}/leave`);
+    return response.data;
+  } catch (error) {
+    throw error;
+  }
+};
+
+export const cancelJoinSocial = async ({ id }: leaveJoinSocialRequest) => {
+  try {
+    const response = await instance.put(API_PATH.SOCIAL + `/${id}/cancel`);
+    return response.data;
+  } catch (error) {
+    throw error;
+  }
+};

--- a/src/api/mypage/type.ts
+++ b/src/api/mypage/type.ts
@@ -1,0 +1,31 @@
+import { LocationType, SocialType } from '@/api/social/type';
+
+export interface GetJoinedSocialListParams {
+  completed?: boolean;
+  reviewed?: boolean;
+  limit?: number;
+  offset?: number;
+  sortBy?: 'dateTime' | 'registrationEnd' | 'joinedAt';
+  sortOrder?: 'asc' | 'desc';
+}
+
+export interface JoinedSocialResponse {
+  id: string;
+  type: SocialType | 'DALLAEMFIT';
+  name: string;
+  dateTime: string;
+  registrationEnd: string;
+  location: LocationType;
+  participantCount: number;
+  capacity: number;
+  image: string;
+  createdBy: number;
+  canceledAt: string;
+  joinedAt: string;
+  isCompleted: boolean;
+  isReviewed: boolean;
+}
+
+export interface leaveJoinSocialRequest {
+  id: string;
+}

--- a/src/app/mypage/mySocial/LoadingListCard.tsx
+++ b/src/app/mypage/mySocial/LoadingListCard.tsx
@@ -1,0 +1,29 @@
+import ListCard from '@/components/common/Card/ListCard';
+
+const LoadingListCards = () => (
+  <>
+    {Array.from({ length: 2 }).map((_, index) => (
+      <div key={index} className="truncate py-6">
+        <ListCard
+          teamUserRole="MEMBER"
+          pageId=""
+          image={{ src: '', alt: '섬네일 이미지' }}
+          chip
+          textContent={{
+            title: '',
+            genre: '',
+            participantCount: 0,
+            capacity: 0,
+          }}
+          endDate=""
+          isCardDataLoading
+          isCompletedStory={false}
+          isCanceled={false}
+          handleButtonClick={() => {}}
+        />
+      </div>
+    ))}
+  </>
+);
+
+export default LoadingListCards;

--- a/src/app/mypage/mySocial/MySocialList.tsx
+++ b/src/app/mypage/mySocial/MySocialList.tsx
@@ -1,0 +1,93 @@
+'use client';
+import { getJoinedSocialList } from '@/api/mypage/api';
+import { getSocialList } from '@/api/social/api';
+import LoadingListCards from '@/app/mypage/mySocial/LoadingListCard';
+import SocialListCards from '@/app/mypage/mySocial/SocialListCards';
+import TabMenu from '@/app/mypage/mySocial/TabMenu';
+import { TabType } from '@/app/mypage/mySocial/type';
+import Observer from '@/components/common/Observer/Observer';
+import { useGetMyInfo } from '@/hooks/api/users/useGetMyInfo';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { useEffect, useState } from 'react';
+
+const FETCH_LIMIT = 12;
+
+const MySocialList = () => {
+  const [activeTab, setActiveTab] = useState<TabType>('joined');
+  const { data: myInfo, isLoading: isMyInfoLoading } = useGetMyInfo(true);
+  const userId = myInfo?.id;
+
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetching,
+    isLoading: isSocialListLoading,
+    refetch,
+  } = useInfiniteQuery({
+    queryKey: ['mySocialList', activeTab, userId],
+    enabled: !!userId,
+    queryFn: async ({ pageParam = 0 }) => {
+      const filter = {
+        limit: FETCH_LIMIT,
+        offset: pageParam,
+        ...(activeTab === 'created' && { createdBy: userId }),
+      };
+
+      return activeTab === 'joined'
+        ? await getJoinedSocialList(filter)
+        : await getSocialList(filter);
+    },
+    getNextPageParam: (lastPage, allPages) =>
+      lastPage.length === FETCH_LIMIT
+        ? allPages.length * FETCH_LIMIT
+        : undefined,
+    initialPageParam: 0,
+  });
+
+  const handleTabChange = (tab: TabType) => {
+    setActiveTab(tab);
+  };
+
+  const flattenedList = data?.pages.flat() || [];
+
+  const isLoading = isMyInfoLoading || isSocialListLoading;
+
+  useEffect(() => {
+    console.log(flattenedList);
+  }, []);
+
+  return (
+    <div className="mt-[30px] w-full border-t-2 border-gray-900 p-6">
+      <TabMenu activeTab={activeTab} onTabChange={handleTabChange} />
+
+      <div className="min-h-[50vh] w-full">
+        {isLoading && <LoadingListCards />}
+
+        {!isLoading && flattenedList.length === 0 && (
+          <p className="py-6 pt-[20vh] text-center text-gray-500">
+            {activeTab === 'joined'
+              ? '내가 참여한 모임이 아직 없어요'
+              : '내가 만든 모임이 아직 없어요'}
+          </p>
+        )}
+
+        {!isLoading && flattenedList.length > 0 && (
+          <SocialListCards
+            list={flattenedList}
+            activeTab={activeTab}
+            refetch={refetch}
+          />
+        )}
+
+        <Observer
+          enabled={hasNextPage && !isFetching}
+          onIntersect={() => fetchNextPage()}
+          threshold={0.1}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default MySocialList;

--- a/src/app/mypage/mySocial/SocialListCards.tsx
+++ b/src/app/mypage/mySocial/SocialListCards.tsx
@@ -1,0 +1,58 @@
+import { cancelJoinSocial, leaveJoinSocial } from '@/api/mypage/api';
+import { convertLocationToGenre } from '@/utils/convertLocationToGenre';
+import { SocialListCardsProps } from '@/app/mypage/mySocial/type';
+import ListCard from '@/components/common/Card/ListCard';
+
+const SocialListCards = ({
+  list,
+  activeTab,
+  refetch,
+}: SocialListCardsProps) => {
+  const handleQuitSocial = async (id: string) => {
+    try {
+      if (activeTab === 'joined') {
+        await leaveJoinSocial({ id }).then(() => {
+          alert('모임 취소 완료!');
+        });
+      } else {
+        await cancelJoinSocial({ id }).then(() => {
+          alert('모임 삭제 완료!');
+        });
+      }
+      refetch();
+    } catch {
+      throw new Error('모임 취소 실패');
+    }
+  };
+  return (
+    <>
+      {list.map((item) => (
+        <div key={`${activeTab}-${item.id}`} className="truncate py-6">
+          <ListCard
+            teamUserRole={activeTab === 'created' ? 'LEADER' : 'MEMBER'}
+            pageId={item.id || ''}
+            image={{ src: item.image || '', alt: item.name || '섬네일 이미지' }}
+            chip
+            textContent={{
+              title: item.name || '',
+              genre:
+                convertLocationToGenre({ location: item.location }) ||
+                '장르 없음',
+              participantCount: item.participantCount || 0,
+              capacity: item.capacity || 0,
+            }}
+            endDate={item.registrationEnd || ''}
+            isCardDataLoading={false}
+            isCompletedStory={false}
+            isCanceled={false}
+            handleButtonClick={() => {
+              handleQuitSocial(item.id);
+            }}
+          />
+        </div>
+      ))}
+    </>
+  );
+};
+
+export default SocialListCards;

--- a/src/app/mypage/mySocial/TabMenu.tsx
+++ b/src/app/mypage/mySocial/TabMenu.tsx
@@ -1,0 +1,23 @@
+import { TabMenuProps } from '@/app/mypage/mySocial/type';
+
+const TabMenu = ({ activeTab, onTabChange }: TabMenuProps) => (
+  <ul className="flex gap-3 font-semibold text-gray-900">
+    {(['joined', 'created'] as const).map((tab) => (
+      <li
+        key={tab}
+        onClick={() => onTabChange(tab)}
+        className="flex cursor-pointer flex-col items-center"
+      >
+        <span className={activeTab === tab ? 'text-gray-900' : 'text-gray-400'}>
+          {tab === 'joined' ? '내가 참여한 모임' : '내가 만든 모임'}
+        </span>
+        <div
+          className={`mt-1 h-[2px] w-full transition-all ${
+            activeTab === tab ? 'bg-gray-900' : 'bg-transparent'
+          }`}
+        />
+      </li>
+    ))}
+  </ul>
+);
+export default TabMenu;

--- a/src/app/mypage/mySocial/type.ts
+++ b/src/app/mypage/mySocial/type.ts
@@ -1,0 +1,17 @@
+import { JoinedSocialResponse } from '@/api/mypage/type';
+import { SocialResponse } from '@/api/social/type';
+
+export type TabType = 'joined' | 'created';
+
+export interface TabMenuProps {
+  activeTab: TabType;
+  onTabChange: (tab: TabType) => void;
+}
+
+type SocialItem = JoinedSocialResponse | SocialResponse;
+
+export interface SocialListCardsProps {
+  list: SocialItem[];
+  activeTab: TabType;
+  refetch: () => void;
+}

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,10 +1,11 @@
 import MyProfile from './myProfile/MyProfile';
-
+import MySocialList from '@/app/mypage/mySocial/MySocialList';
 const MyPage = () => {
   return (
     <section className="mx-auto mt-4 w-[343px] md:w-[696px] lg:w-[996px]">
       <h1 className="text-write-main text-2xl font-semibold">마이 페이지</h1>
       <MyProfile />
+      <MySocialList />
     </section>
   );
 };


### PR DESCRIPTION
## PR요약
마이페이지 내 MySocialList의 api 요청 방식과 useInfinteQuery를 사용해 무한 스크롤 기능을 구현하였습니다.



### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 스타일 관련
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트



### 변경 사항
- MySocialList를 분기별 Component로 분리
- useInfinteQuery를 사용한 무한 스크롤 기능 구현
- 데이터 가져올 시 보이는 Skeleton UI 적용
- 내가 만든 모임일 시  leaveJoinSocial, 내가 참여한 모임일 시 cancelJoinSocial로 모임 참여 취소




### 구현결과(사진첨부 선택)

![Animation1](https://github.com/user-attachments/assets/5ad55d53-7d9d-4448-81ab-10abc461c5bd)
