### PR TITLE
Fix: 모임 상세 페이지의 텍스트 에디터 내부 입력 영역이 에디터 컨테이너를 초과하는 문제 수정

### DIFF
--- a/src/components/common/TextEditor/TextEditor.tsx
+++ b/src/components/common/TextEditor/TextEditor.tsx
@@ -148,6 +148,12 @@ const TextEditor = forwardRef(
           ref={editorContentRef}
           editor={editor}
           className={`mt-2 overflow-y-auto h-[${editorHeight}]`}
+          style={{
+            height:
+              !isReadOnly && useToolbarMenu
+                ? `calc(${editorHeight} - 20px)`
+                : editorHeight,
+          }}
         />
       </div>
     );

--- a/src/components/common/TextEditor/TextEditor.tsx
+++ b/src/components/common/TextEditor/TextEditor.tsx
@@ -147,7 +147,7 @@ const TextEditor = forwardRef(
         <EditorContent
           ref={editorContentRef}
           editor={editor}
-          className={`mt-2 overflow-y-auto h-[${editorHeight}]`}
+          className={`mt-2 overflow-y-auto`}
           style={{
             height:
               !isReadOnly && useToolbarMenu


### PR DESCRIPTION
## PR요약
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 스타일 관련
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트



### 변경 사항
![screencapture-localhost-3000-social-detail-2571-2025-06-08-15_50_56](https://github.com/user-attachments/assets/1700fc81-f568-4c40-bda3-d3935b85512c)
before (에디터 컨테이너를 초과)

![screencapture-localhost-3000-social-detail-2571-2025-06-08-15_49_52](https://github.com/user-attachments/assets/abc5ad06-46db-4cbd-93f6-9aa4afff28dd)
after (내부에서 스크롤 생김)

에디터의 입력 가능한 높이가
- 툴바가 존재할 경우 -> `calc(${editorHeight} - 20px)` (툴바 높이 20px를 제외)
- 툴바가 존재하지 않을 경우 -> editorHeight 그대로 높이 출력
으로 설정되도록 변경하였습니다.

아직 텍스트 에디터가 사용되는 페이지가 모임 상세, 스토리 상세 글쓰기 모달 두 곳뿐이라
다양하게 테스트가 못 이루어졌습니다. 추후 다른 텍스트 에디터 리팩토링 및 버그 픽스와 함께
에디터 높이 설정에 대한 부분도 다시 조정하겠습니다.