### PR TITLE
Refactor: 모임 상세 페이지 소개글 영역에 반응형 padding, margin 적용

### DIFF
--- a/src/app/social/detail/[socialId]/StorySummary.tsx
+++ b/src/app/social/detail/[socialId]/StorySummary.tsx
@@ -48,7 +48,7 @@ const StorySummary = ({
   };
 
   return (
-    <div className="mt-24 px-10">
+    <div className="mt-32 sm:mt-24 xl:px-10">
       <h2 className="mx-1 mb-4 text-2xl font-semibold">스토리 소개글</h2>
       {userRoleData?.role === 'LEADER' && !summaryData?.summary ? (
         <div className="flex h-240 w-full flex-col">


### PR DESCRIPTION
## PR요약




### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 스타일 관련
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트



### 변경 사항
![소개글 좌우 패딩 before](https://github.com/user-attachments/assets/ab9faaf0-0ba5-4231-a0dc-e5090a1186b4)
before

![소개글 좌우 패딩 해결](https://github.com/user-attachments/assets/fc3df97d-c094-49b4-aee7-d171fc4c3860)
after

일정 뷰포트 아래에서 텍스트 에디터의 좌우 너비가 지나치게 좁아 UX에 해가 되는 부분을 개선하였습니다.