### PR TITLE
Feat: 외부 클릭 감지 custom hook

### DIFF
--- a/src/hooks/useClickOutside.ts
+++ b/src/hooks/useClickOutside.ts
@@ -1,0 +1,18 @@
+import { RefObject, useEffect } from 'react';
+
+export const useClickOutside = (
+  ref: RefObject<HTMLElement>,
+  handler: () => void
+) => {
+  useEffect(() => {
+    const listener = (event: MouseEvent) => {
+      if (!ref.current || ref.current.contains(event.target as Node)) return;
+      handler();
+    };
+
+    document.addEventListener('mousedown', listener);
+    return () => {
+      document.removeEventListener('mousedown', listener);
+    };
+  }, [ref, handler]);
+};


### PR DESCRIPTION
## PR요약
요소의 외부 클릭을 감지하기 위한 커스텀 훅입니다.

![custom](https://github.com/user-attachments/assets/399cf58c-5326-46ec-993f-5d5f68efcfbb)

이런 식으로 ref와 함수를 연결시켜 사용할 수 있습니다.






### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 스타일 관련
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트






### 구현결과(사진첨부 선택)
(드랍다운 사용 예시)
![outsideclick](https://github.com/user-attachments/assets/96ced193-3563-462c-bcc9-1f3a8ab5b673)
