### PR TITLE
Fix: 모임 요약 데이터 표시

### DIFF
--- a/src/api/stories/api.ts
+++ b/src/api/stories/api.ts
@@ -40,6 +40,21 @@ export const getStories = async ({
   return data;
 };
 
+export const getSocialSummary = async (id: string) => {
+  const { data, error } = await instanceBaaS
+    .from('Stories')
+    .select('*')
+    .eq('social_id', id)
+    .single();
+
+  if (error) {
+    console.error('Error fetching summary:', error);
+    return '모임장이 소개글을 작성하고 있어요!';
+  }
+
+  return data?.summary || '모임장이 소개글을 작성하고 있어요!';
+};
+
 export const getStory = async (id: string) => {
   const { data, error } = await instanceBaaS
     .from('Stories')

--- a/src/app/social/SocialList.tsx
+++ b/src/app/social/SocialList.tsx
@@ -4,24 +4,11 @@ import { useGetSocialList } from '@/hooks/api/social';
 import Observer from '@/components/common/Observer/Observer';
 import { convertLocationToGenre } from '@/utils/convertLocationToGenre';
 import GridCard from '@/components/common/Card/GridCard';
-import { useQuery } from '@tanstack/react-query';
 import htmlToString from '@/utils/htmlToString';
-import { getSocialSummary } from '@/api/stories/api';
+import useGetSocialSummary from '@/hooks/api/stories/useGetSocialSummary';
 
 const SocialListGrid = ({ socialList, isLoading }: SocialListGridProps) => {
-  const { data: summaryData } = useQuery({
-    queryKey: ['socialSummary', socialList.map((item) => item.id)],
-    queryFn: async () => {
-      const summaries = await Promise.all(
-        socialList.map(async (item) => {
-          const summary = await getSocialSummary(item.id);
-          return summary;
-        })
-      );
-      return summaries;
-    },
-    enabled: !!socialList.length,
-  });
+  const { data: summaryData } = useGetSocialSummary(socialList);
 
   if (!isLoading && socialList.length === 0) {
     return (

--- a/src/app/social/SocialList.tsx
+++ b/src/app/social/SocialList.tsx
@@ -39,9 +39,7 @@ const SocialListGrid = ({ socialList, isLoading }: SocialListGridProps) => {
             description:
               summaryData && summaryData[index]
                 ? htmlToString(summaryData[index])
-                : isLoading
-                  ? '로딩 중...'
-                  : '모임장이 소개글을 작성하고 있어요!',
+                : '모임장이 소개글을 작성하고 있어요!',
           }}
           isCardDataLoading={isLoading || !summaryData}
         />

--- a/src/app/social/SocialList.tsx
+++ b/src/app/social/SocialList.tsx
@@ -8,7 +8,8 @@ import htmlToString from '@/utils/htmlToString';
 import useGetSocialSummary from '@/hooks/api/stories/useGetSocialSummary';
 
 const SocialListGrid = ({ socialList, isLoading }: SocialListGridProps) => {
-  const { data: summaryData } = useGetSocialSummary(socialList);
+  const { data: summaryData, isLoading: isSummaryLoading } =
+    useGetSocialSummary(socialList);
 
   if (!isLoading && socialList.length === 0) {
     return (
@@ -41,7 +42,7 @@ const SocialListGrid = ({ socialList, isLoading }: SocialListGridProps) => {
                 ? htmlToString(summaryData[index])
                 : '모임장이 소개글을 작성하고 있어요!',
           }}
-          isCardDataLoading={isLoading || !summaryData}
+          isCardDataLoading={isLoading || isSummaryLoading}
         />
       ))}
     </div>

--- a/src/app/social/SocialList.tsx
+++ b/src/app/social/SocialList.tsx
@@ -50,10 +50,13 @@ const SocialListGrid = ({ socialList, isLoading }: SocialListGridProps) => {
               convertLocationToGenre({ location: item.location }) ||
               '장르 없음',
             description:
-              htmlToString(summaryData?.[index]) ||
-              '모임장이 소개글을 작성하고 있어요!',
+              summaryData && summaryData[index]
+                ? htmlToString(summaryData[index])
+                : isLoading
+                  ? '로딩 중...'
+                  : '모임장이 소개글을 작성하고 있어요!',
           }}
-          isCardDataLoading={isLoading}
+          isCardDataLoading={isLoading || !summaryData}
         />
       ))}
     </div>

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -7,4 +7,5 @@ export const QUERY_KEY = {
   GET_APPROVE_USER: 'get-approve-user',
   GET_LAST_CONTENT: 'get-last-content',
   SOCIAL: 'social',
+  SOCIAL_SUMMARY: 'social-summary',
 } as const;

--- a/src/hooks/api/stories/useGetSocialSummary.ts
+++ b/src/hooks/api/stories/useGetSocialSummary.ts
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query';
+import { getSocialSummary } from '@/api/stories/api';
+import { SocialResponse } from '@/api/social/type';
+import { QUERY_KEY } from '@/constants/queryKey';
+
+const useGetSocialSummary = (socialList: SocialResponse[]) => {
+  return useQuery({
+    queryKey: [QUERY_KEY.SOCIAL_SUMMARY, socialList.map((item) => item.id)],
+    queryFn: async () => {
+      const summaries = await Promise.all(
+        socialList.map(async (item) => {
+          const summary = await getSocialSummary(item.id);
+          return summary;
+        })
+      );
+      return summaries;
+    },
+    enabled: !!socialList.length,
+  });
+};
+
+export default useGetSocialSummary;


### PR DESCRIPTION
## 이슈[161]

## PR요약
<!---- PR제목은 [기능]: '제목"으로 작성해주세요 ex) Feat : 로그인/회원가입기능 폼구현. -->
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

### 모임의 요약(summary)를 표시합니다.



### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 스타일 관련
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트



### 변경 사항

### 요약글 가져오기 함수 구현
```tsx
queryFn: async () => {
      const summaries = await Promise.all(
        socialList.map(async (item) => {
          const summary = await getSocialSummary(item.id);
          return summary;
        })
      );
      return summaries;
    },
```

지혁님께서도 사용하셨던 Promise.all을 적용해서 병렬적으로 데이터를 가져올 수 있도록 구현했습니다.




### 구현결과(사진첨부 선택)

https://github.com/user-attachments/assets/96f4d023-3124-4e4d-ac40-fc8d50063230

