### PR TITLE
Fix: Modal 열릴 시 배경 스크롤 제어

### DIFF
--- a/src/components/common/Modal/Modal.tsx
+++ b/src/components/common/Modal/Modal.tsx
@@ -5,7 +5,7 @@ import {
   ModalFooterProps,
   CloseButtonProps,
 } from './type';
-import React from 'react';
+import React, { useEffect } from 'react';
 
 export const Modal = ({
   isOpen,
@@ -17,7 +17,18 @@ export const Modal = ({
   children,
   className,
 }: ModalProps) => {
-  if (isOpen) document.body.style.overflow = 'hidden';
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+
+    // 언마운트 시 원상 복구
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isOpen]);
   if (!isOpen) return null;
   const backdropStyle =
     'fixed inset-0 z-50 flex items-center justify-center visible opacity-100"';

--- a/src/components/common/Modal/Modal.tsx
+++ b/src/components/common/Modal/Modal.tsx
@@ -17,6 +17,7 @@ export const Modal = ({
   children,
   className,
 }: ModalProps) => {
+  if (isOpen) document.body.style.overflow = 'hidden';
   if (!isOpen) return null;
   const backdropStyle =
     'fixed inset-0 z-50 flex items-center justify-center visible opacity-100"';

--- a/src/components/common/Modal/Modal.tsx
+++ b/src/components/common/Modal/Modal.tsx
@@ -14,11 +14,12 @@ export const Modal = ({
   closeButtonDark,
   noCloseButton,
   fullScreen,
+  backdropNoScroll = false,
   children,
   className,
 }: ModalProps) => {
   useEffect(() => {
-    if (isOpen) {
+    if (isOpen && backdropNoScroll) {
       document.body.style.overflow = 'hidden';
     } else {
       document.body.style.overflow = '';
@@ -28,7 +29,7 @@ export const Modal = ({
     return () => {
       document.body.style.overflow = '';
     };
-  }, [isOpen]);
+  }, [isOpen, backdropNoScroll]);
   if (!isOpen) return null;
   const backdropStyle =
     'fixed inset-0 z-50 flex items-center justify-center visible opacity-100"';

--- a/src/components/common/Modal/type.ts
+++ b/src/components/common/Modal/type.ts
@@ -5,6 +5,7 @@ export interface ModalProps {
   closeButtonDark?: boolean;
   noCloseButton?: boolean;
   fullScreen?: boolean;
+  backdropNoScroll?: boolean;
   children: React.ReactNode;
   className?: string;
 }


### PR DESCRIPTION
## PR요약
Modal이 열릴 시 body의 scroll을 hidden되고 
다시 Modal이 닫히면 body의 scroll이 활성화되게 하였습니다.



### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [x] 스타일 관련
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트



### 변경 사항
- Modal 열릴시 body overflow hidden 추가
- Modal 닫힐시 body overflow hidden 제거





### 구현결과(사진첨부 선택)
![modalscroll](https://github.com/user-attachments/assets/6162d58c-a9c4-4171-b229-1317867afe10)

