### PR TITLE
Fix: 비로그인시 mypage에서 로그인페이지로 redirect

### DIFF
--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,6 +1,13 @@
+'use client';
+
+import { useAuth } from '@/utils/authContext';
 import MyProfile from './myProfile/MyProfile';
 import MySocialList from '@/app/mypage/mySocial/MySocialList';
+import { redirect } from 'next/navigation';
+import { APP_ROUTES } from '@/constants/appRoutes';
 const MyPage = () => {
+  const { isSignIn } = useAuth();
+  if (!isSignIn) return redirect(APP_ROUTES.signin);
   return (
     <section className="mx-auto mt-4 w-[343px] md:w-[696px] lg:w-[996px]">
       <h1 className="text-write-main text-2xl font-semibold">마이 페이지</h1>


### PR DESCRIPTION
## PR요약
로그인 안하고 mypage에 접근하려 할때 로그인 페이지로 이동하게 redirect를 설정해주었습니다.



### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 스타일 관련
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트



### 변경 사항
- 비로그인시 /auths/signin 으로 redirect





### 구현결과(사진첨부 선택)
![mypage](https://github.com/user-attachments/assets/c7a2d96c-c810-4501-9eb5-49b427b41ae7)
