### PR TITLE
Fix: 소개글 및 작성글 빈 값으로 요청이 보내지는 문제 수정 (글자 수 제한 적용)

### DIFF
--- a/src/app/social/detail/[socialId]/StorySummary.tsx
+++ b/src/app/social/detail/[socialId]/StorySummary.tsx
@@ -7,13 +7,17 @@ import { useEffect, useRef, useState } from 'react';
 import { SummaryProps } from '@/app/social/detail/[socialId]/type';
 import useGetSummary from '@/hooks/api/teams/useGetSummary';
 import useGetUserRole from '@/hooks/api/teams/useGetUserRole';
+import { TextEditorRef } from '@/types/textEditor';
+import validateEditorContent from '@/utils/validators/validateEditorContent';
+
+const SUMMARY_MIN_LENGTH = 10;
 
 const StorySummary = ({
   currentSocialId,
   currentUserId,
   currentStoryId,
 }: SummaryProps) => {
-  const editorContentRef = useRef<{ getHTML: () => string }>(null);
+  const editorContentRef = useRef<TextEditorRef>(null);
   const [extractionHtml, setExtractionHtml] = useState('');
   const { data: summaryData } = useGetSummary({
     socialId: currentSocialId,
@@ -35,16 +39,16 @@ const StorySummary = ({
   }, [summaryData?.summary]);
 
   const handleStoryIntroductionSubmit = () => {
-    if (!editorContentRef.current) {
-      console.warn('Editor ref가 존재하지 않습니다.');
-      return;
-    }
-    const newExtractionHtml = editorContentRef.current.getHTML();
+    const validateResult = validateEditorContent({
+      ref: editorContentRef,
+      minLength: SUMMARY_MIN_LENGTH,
+    });
+    if (!validateResult) return;
     mutate({
       socialId: currentSocialId,
-      summaryHtml: newExtractionHtml,
+      summaryHtml: validateResult.newExtractionHtml,
     });
-    setExtractionHtml(newExtractionHtml);
+    setExtractionHtml(validateResult.newExtractionHtml);
   };
 
   return (

--- a/src/components/common/TextEditor/TextEditor.tsx
+++ b/src/components/common/TextEditor/TextEditor.tsx
@@ -116,9 +116,11 @@ const TextEditor = forwardRef(
         editor
           ? {
               getHTML: () => editor.getHTML(),
+              getText: () => editor.getText(),
             }
           : {
               getHTML: () => '',
+              getText: () => '',
             },
       [editor]
     );

--- a/src/types/textEditor.ts
+++ b/src/types/textEditor.ts
@@ -1,0 +1,4 @@
+export interface TextEditorRef {
+  getHTML: () => string;
+  getText: () => string;
+}

--- a/src/utils/validators/validateEditorContent.ts
+++ b/src/utils/validators/validateEditorContent.ts
@@ -1,0 +1,41 @@
+import { TextEditorRef } from '@/types/textEditor';
+import { RefObject } from 'react';
+
+type ValidateEditorContentParams = {
+  ref: RefObject<TextEditorRef | null>;
+  minLength?: number;
+  alertMessage?: string;
+};
+
+type EditorValidationResult =
+  | false
+  | {
+      isValid: true;
+      newExtractionHtml: string;
+      newExtractionPureString: string;
+    };
+
+const validateEditorContent = ({
+  ref,
+  minLength = 10,
+  alertMessage = `최소 ${minLength}자 이상의 내용을 입력해주세요.`,
+}: ValidateEditorContentParams): EditorValidationResult => {
+  if (!ref.current) {
+    console.warn('Editor ref가 존재하지 않습니다.');
+    return false;
+  }
+  const newExtractionHtml = ref.current.getHTML();
+  const newExtractionPureString = ref.current.getText();
+
+  if (
+    !newExtractionPureString ||
+    newExtractionPureString.trim().length < minLength
+  ) {
+    alert(alertMessage);
+    return false;
+  }
+
+  return { isValid: true, newExtractionHtml, newExtractionPureString };
+};
+
+export default validateEditorContent;


### PR DESCRIPTION
## PR요약




### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 스타일 관련
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트



### 변경 사항
1. 소개글은 최소 `10자`이상, 작성한 스토리 컨텐츠는 최소 `20자`이상을 입력해야만 DB에 등록이 가능하도록 설정하였습니다.
2. 사용자가 현재 몇 자를 입력했는 지를 확인하기 위하여 `TextEditor` 컴포넌트에서 `HTML문자열`과 함께 `순수 문자열`을 내보내도록 설정하였습니다.
3. 순수 문자열 `getText()`의 추가로 타입의 길이가 길어지고, 동일한 타입을 중복으로 선언되는 케이스가 많아져서, 전역 `types`폴더에 `TextEditorRef` 타입 선언하고 각 컴포넌트 및 유틸 함수에서 가져오는 방식으로 변경하였습니다.
4. `ref`에서 문자열 추출 및 유효성 검사(ref존재 유무, 글자 수 제한 충족 여부)를 실행하는 공통 유틸리티 함수 추가하였습니다.

소개 글 빈 값 등록을 막는 `fix` 브랜치로 시작했는데, 작업하다보니 욕심이 나서 공통 함수 추가같은 리팩토링 요소까지
해당 PR에 포함됐습니다,, 앞으로 브랜치의 의미를 더 명확하게 가져갈 수 있도록 신경쓰겠습니다
