### PR TITLE
Fix: 로그인되지 않은 사용자가 참여하기 버튼을 클릭하면 alert와 함께 로그인 페이지로 리다이렉트 되도록 설정

### DIFF
--- a/src/app/social/detail/[socialId]/SocialOverView.tsx
+++ b/src/app/social/detail/[socialId]/SocialOverView.tsx
@@ -46,6 +46,7 @@ const SocialOverView = ({
     if (role === 'GUEST') {
       if (currentUserId) {
         joinTeam();
+        return;
       }
       alert('로그인이 필요한 서비스입니다.');
       router.push('/auths/signin');

--- a/src/app/social/detail/[socialId]/SocialOverView.tsx
+++ b/src/app/social/detail/[socialId]/SocialOverView.tsx
@@ -44,7 +44,11 @@ const SocialOverView = ({
 
   const navigateStoryOrJoinTeam = (role: TeamUserRole) => {
     if (role === 'GUEST') {
-      joinTeam();
+      if (currentUserId) {
+        joinTeam();
+      }
+      alert('로그인이 필요한 서비스입니다.');
+      router.push('/auths/signin');
     } else if (role === 'MEMBER' || role === 'LEADER') {
       router.push(`/library/detail/${currentStoryId}`);
     }


### PR DESCRIPTION
## PR요약
> `Netlify` 깃헙 배포 설정 문제로 에러가 발생하여 기존 PR을 닫고 새로 생성했습니다.



### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 스타일 관련
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트



### 변경 사항
모임 상세 페이지에서 로그인 되지 않은 사용자(`currentUserId`가 존재하지 않는 사용자)가 참여하기 버튼을 클릭하면,
alert를 띄우고, 로그인 페이지로 리다이렉트 되도록 하였습니다.
