### PR TITLE
Feat: 모임 참여에 성공하면 DB 테이블에 사용자 정보가 입력되는 기능 구현

### DIFF
--- a/src/api/story-collaborators/api.ts
+++ b/src/api/story-collaborators/api.ts
@@ -1,12 +1,9 @@
-import { TeamUserRole } from '@/types/teamUserRole';
 import instanceBaaS from '../instanceBaaS';
-import { CreateCollaboratorRequest } from './type';
 import { DB_PATH } from '@/constants/apiPath';
+import { CreateCollaboratorParams } from './type';
 
-export const createCollaborator = async (
-  data: CreateCollaboratorRequest,
-  role: TeamUserRole
-) => {
+export const createCollaborator = async (params: CreateCollaboratorParams) => {
+  const { data, role } = params;
   const response = await instanceBaaS.from(DB_PATH.STORY_COLLABORATORS).insert({
     ...data,
     role,

--- a/src/api/story-collaborators/type.ts
+++ b/src/api/story-collaborators/type.ts
@@ -1,6 +1,13 @@
+import { TeamUserRole } from '@/types/teamUserRole';
+
 export interface CreateCollaboratorRequest {
   story_id: string;
   user_id: number;
   user_name: string;
   joined_at: string;
+}
+
+export interface CreateCollaboratorParams {
+  data: CreateCollaboratorRequest;
+  role: TeamUserRole;
 }

--- a/src/app/social/createSocialForm/useCreateSocialForm.ts
+++ b/src/app/social/createSocialForm/useCreateSocialForm.ts
@@ -103,7 +103,10 @@ const useCreateSocialForm = (onClose: () => void) => {
   const createCollaboratorAsLeader = async (
     data: CreateCollaboratorRequest
   ) => {
-    const response = await createCollaborator(data, TEAM_USER_ROLE.LEADER);
+    const response = await createCollaborator({
+      data: data,
+      role: TEAM_USER_ROLE.LEADER,
+    });
     // TODO: 응답값 개선 하기(#150 PR)
     return response;
   };

--- a/src/app/social/detail/[socialId]/SocialOverView.tsx
+++ b/src/app/social/detail/[socialId]/SocialOverView.tsx
@@ -2,7 +2,7 @@
 
 import DetailCard from '@/components/common/Card/DetailCard';
 import useJoinTeam from '@/hooks/api/teams/useJoinTeam';
-import { TeamUserRole } from '@/types/teamUserRole';
+import { TEAM_USER_ROLE, TeamUserRole } from '@/types/teamUserRole';
 import convertLocationToGenre from '@/utils/convertLocationToGenre';
 import Image from 'next/image';
 import { SocialOverViewProps } from '@/app/social/detail/[socialId]/type';
@@ -11,10 +11,12 @@ import useGetSocialDetail from '@/hooks/api/teams/useGetSocialDetail';
 import useGetSocialParticipants from '@/hooks/api/teams/useGetSocialParticipants';
 import useGetUserRole from '@/hooks/api/teams/useGetUserRole';
 import { useRouter } from 'next/navigation';
+import useParticipateCollaborator from '@/hooks/api/teams/useParticipateCollaborator';
 
 const SocialOverView = ({
   currentSocialId,
   currentUserId,
+  currentUserName,
   currentStoryId,
 }: SocialOverViewProps) => {
   const { data: socialDetailData, isLoading: socialDetailDataIsLoading } =
@@ -36,6 +38,9 @@ const SocialOverView = ({
   const { mutate: joinTeam } = useJoinTeam({
     socialId: currentSocialId,
   });
+  const { mutate: insertNewCollaborator } = useParticipateCollaborator({
+    socialId: currentSocialId,
+  });
   const imagesUrls = extractUserImages(socialTeamsParticipantsData);
   const currentUserRole: TeamUserRole = userRoleData
     ? userRoleData.role
@@ -43,9 +48,22 @@ const SocialOverView = ({
   const router = useRouter();
 
   const navigateStoryOrJoinTeam = (role: TeamUserRole) => {
+    if (!currentStoryId) {
+      alert('스토리 정보를 불러오지 못했습니다. 잠시 후에 다시 시도해주세요.');
+      return;
+    }
     if (role === 'GUEST') {
-      if (currentUserId) {
+      if (currentUserId && currentUserName) {
         joinTeam();
+        insertNewCollaborator({
+          data: {
+            story_id: currentStoryId,
+            user_id: currentUserId,
+            user_name: currentUserName,
+            joined_at: new Date().toISOString(),
+          },
+          role: TEAM_USER_ROLE.MEMBER,
+        });
         return;
       }
       alert('로그인이 필요한 서비스입니다.');

--- a/src/app/social/detail/[socialId]/page.tsx
+++ b/src/app/social/detail/[socialId]/page.tsx
@@ -65,6 +65,9 @@ const SocialDetail = async ({
           {...(userInfo.id !== 'unauthenticated' && {
             currentUserId: userInfo.id,
           })}
+          {...(userInfo.id !== 'unauthenticated' && {
+            currentUserName: userInfo.name,
+          })}
           {...(storyId! && { currentStoryId: storyId.story_id })}
         />
         <StorySummary

--- a/src/app/social/detail/[socialId]/type.ts
+++ b/src/app/social/detail/[socialId]/type.ts
@@ -5,6 +5,7 @@ export interface SocialDetailPageParams {
 export interface SocialOverViewProps {
   currentSocialId: number;
   currentUserId?: number;
+  currentUserName?: string;
   currentStoryId?: string;
 }
 

--- a/src/hooks/api/teams/useParticipateCollaborator.ts
+++ b/src/hooks/api/teams/useParticipateCollaborator.ts
@@ -1,0 +1,26 @@
+import { createCollaborator } from '@/api/story-collaborators/api';
+import { QUERY_KEY } from '@/constants/queryKey';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+interface useParticipateCollaboratorParams {
+  socialId: number;
+}
+
+const useParticipateCollaborator = ({
+  socialId,
+}: useParticipateCollaboratorParams) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: createCollaborator,
+    onError: (error) => {
+      console.error(error);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEY.SOCIAL_PARTICIPANTS, socialId],
+      });
+    },
+  });
+};
+
+export default useParticipateCollaborator;


### PR DESCRIPTION
## PR요약
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 스타일 관련
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트



### 변경 사항
"모임 참여하기" 버튼을 클릭하면 달램API 모임 참가 요청과 함께, DB `stroy_collaborators`테이블에 사용자 정보가 등록되는
기능을 구현하였습니다.
`useMatation` 커스텀 훅을 사용하여, 호출 성공 시에 `SOCIAL_PARTICIPANTS` key를 가진 API 데이터를 refetch하도록 하였습니다.

특이 사항이라면 명헌님께서 만들어주신 `createCollaborator` 함수의 매개변수를 `data`, `role` 2개의 인자를 받는 기존 방식에서
하나의 객체를 받는 방식으로 변경하였습니다.
이유는 `React Query`의 설계상 제한으로 인해, `useMutation`은 `mutationFn`이 단일 인자만 받도록 강제하기 때문입니다.
즉 아래와 같이 인자를 전달하면 에러가 발생합니다.
```
insertNewCollaborator(
  {
    story_id: ...,
    user_id: ...,
    user_name: ...,
    joined_at: ...,
  },
  TEAM_USER_ROLE.MEMBER
);
```
매개변수의 변경으로 기존에 `createCollaborator`를 호출하던 명헌님의 코드(`useCreateSocialForm.ts`)도 하나의 객체로 묶어 값을 전달하도록 변경하였습니다.