### PR TITLE
Fix: 다른 아이디로 로그인해도 GNB와 마이페이지에선 회원정보가 변하지 않는 문제

### DIFF
--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -7,4 +7,5 @@ export const QUERY_KEY = {
   GET_APPROVE_USER: 'get-approve-user',
   GET_LAST_CONTENT: 'get-last-content',
   SOCIAL: 'social',
+  MY_INFO: 'my-info',
 } as const;

--- a/src/hooks/api/users/useGetMyInfo.ts
+++ b/src/hooks/api/users/useGetMyInfo.ts
@@ -1,10 +1,11 @@
 'use client';
 import { getMyInfo } from '@/api/auth';
+import { QUERY_KEY } from '@/constants/queryKey';
 import { useQuery } from '@tanstack/react-query';
 
 export const useGetMyInfo = (enabled: boolean) => {
   return useQuery({
-    queryKey: ['myInfo'],
+    queryKey: [QUERY_KEY.MY_INFO],
     queryFn: getMyInfo,
     enabled: !!enabled,
   });

--- a/src/hooks/api/users/usePostSignout.ts
+++ b/src/hooks/api/users/usePostSignout.ts
@@ -1,12 +1,15 @@
 import { postSignOut } from '@/api/auth';
 import { deleteCookie } from '@/api/cookies';
-import { useMutation } from '@tanstack/react-query';
+import { QUERY_KEY } from '@/constants/queryKey';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 export const usePostSignout = () => {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: postSignOut,
     onSuccess: () => {
       deleteCookie('accessToken');
+      queryClient.removeQueries({ queryKey: [QUERY_KEY.MY_INFO] });
     },
     onError: (error) => {
       console.error(error);


### PR DESCRIPTION
## 이슈[187]

## PR요약
<!---- PR제목은 [기능]: '제목"으로 작성해주세요 ex) Feat : 로그인/회원가입기능 폼구현. -->
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 로그아웃해도 이전 유저의 정보가 남아 있는 버그 수정했습니다.


### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 스타일 관련
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트



### 변경 사항
<!---- ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. -->
- accessToken의 값은 바뀐 것을 확인했습니다.
- 유저 정보가 리액트 쿼리에 의해서 캐싱되고 있는 것이라 판단했습니다.
- logout 성공시에 userInfo 쿼리를 removeQueries로 지워서 버그를 고쳤습니다.





### 구현결과(사진첨부 선택)
(내용)
