### PR TITLE
Fix: 스토리 상세 페이지에서 HTML문자열이 출력되는 문제 수정 

### DIFF
--- a/src/app/library/detail/[id]/_components/CreateContentModal.tsx
+++ b/src/app/library/detail/[id]/_components/CreateContentModal.tsx
@@ -29,12 +29,12 @@ const CreateContentModal = ({
       console.warn('Editor ref가 존재하지 않습니다.');
       return;
     }
-    const newExtractionHtml = editorContentRef.current.getHTML();
-    if (newExtractionHtml == '<p></p>') {
+    const newExtractionPureString = editorContentRef.current.getText();
+    if (!newExtractionPureString) {
       alert('내용을 작성해주세요.');
       return;
     }
-    localStorage.setItem('TemporaryContent', newExtractionHtml);
+    localStorage.setItem('TemporaryContent', newExtractionPureString);
     alert('임시 저장되었습니다.');
   };
 
@@ -59,7 +59,7 @@ const CreateContentModal = ({
     if (postStoryConfirmed) {
       mutate({
         storyId: currentStoryId,
-        content: validateResult.newExtractionHtml,
+        content: validateResult.newExtractionPureString,
         userId: currentUserId,
       });
       localStorage.removeItem('TemporaryContent');


### PR DESCRIPTION
## PR요약
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 스타일 관련
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트



### 변경 사항
`DB`에 HTML 문자열이 입력되고, 해당 컨텐츠를 가져올 때 다시 HTML태그나 스타일들을 제거하는 파싱을 거치는 것 보다는,
아예 컨텐츠를 등록할 때부터 HTML태그가 제거된 순수 문자열이 저장되도록 변경하였습니다.

`fix/#175-empty-input-db`(`Fix: 소개글 및 작성글 빈 값으로 요청이 보내지는 문제 수정 (글자 수 제한 적용)`) 브랜치에서
분기한 브랜치로 작업해서 그런지 타 커밋들이 PR에 함께 포함된 문제가 있습니다..
빠르게 원인을 파악해서 고쳐보겠습니다!!
해당 PR에서의 변경 사항은 'fix: 작성한 컨텐츠가 DB에 저장될 때, HTML문자열이 아닌 순수 문자열로 들어가도록 수정' 커밋과,
`CreateContentModal.tsx` 파일 하나 입니다.
