### PR TITLE
Feat: 날짜 필터 기능 구현 및 날짜초기화 버튼 기능 구현

### DIFF
--- a/src/app/social/SocialFilterBar.tsx
+++ b/src/app/social/SocialFilterBar.tsx
@@ -8,6 +8,10 @@ import useBoolean from '@/hooks/useBoolean';
 import React from 'react';
 import { FilterProps } from './type';
 import { ArrowSort, DownIcon } from '@public/assets/icons';
+import { useCalendar } from '@/components/common/Calendar/useCalendar';
+import Calendar from '@/components/common/Calendar/Calendar';
+import { format } from 'date-fns';
+import { RefreshCcw } from 'lucide-react';
 
 const GenreFilter = ({ filter, filterDispatch }: FilterProps) => {
   const {
@@ -75,26 +79,84 @@ const GenreFilter = ({ filter, filterDispatch }: FilterProps) => {
   );
 };
 
-const DateFilter = () => {
-  const { value: dateFilterOpen, toggle: toggleDateFilter } = useBoolean();
+const DateFilter = ({ filter, filterDispatch }: FilterProps) => {
+  const {
+    value: dateFilterOpen,
+    toggle: toggleDateFilter,
+    setFalse: closeDateFilter,
+  } = useBoolean();
+  const {
+    currentDate,
+    handleDateSelect,
+    selectedDate,
+    navigateMonth,
+    isSameDay,
+    getDaysInMonth,
+    getFirstDayOfMonth,
+    isDateDisabled,
+  } = useCalendar({
+    initialDate: new Date(),
+    minDate: new Date(),
+  });
+
+  const handleDateFilter = (day: number) => {
+    const newDate = new Date(currentDate);
+    newDate.setDate(day);
+    const formattedDate = format(newDate, 'yyyy-MM-dd');
+
+    filterDispatch({
+      type: 'SET_FILTER',
+      payload: { date: formattedDate },
+    });
+    handleDateSelect(day);
+    closeDateFilter();
+  };
+
+  const handleResetDateFilter = () => {
+    filterDispatch({
+      type: 'REMOVE_FILTER',
+      payload: 'date',
+    });
+  };
 
   return (
     <Dropdown
       isOpen={dateFilterOpen}
       trigger={
-        <Button
-          onClick={toggleDateFilter}
-          size="custom"
-          className="flex min-w-[110px] items-center justify-between rounded-xl border-2 border-gray-200 bg-white px-3 py-2 text-sm font-medium text-gray-800"
-        >
-          날짜 전체
-          <DownIcon fill="currentColor" />
-        </Button>
+        <div className="flex items-center gap-2">
+          <Button
+            onClick={toggleDateFilter}
+            size="custom"
+            className="relative flex min-w-[110px] items-center justify-between rounded-xl border-2 border-gray-200 bg-white px-3 py-2 text-sm font-medium text-gray-800"
+          >
+            {filter.date || '날짜 전체'}
+            <DownIcon fill="currentColor" />
+          </Button>
+
+          {filter.date && (
+            <button
+              onClick={handleResetDateFilter}
+              className="rounded-full bg-gray-100 p-1 hover:bg-gray-200"
+            >
+              <RefreshCcw size={16} className="text-gray-600" />
+            </button>
+          )}
+        </div>
       }
     >
       <Dropdown.Container className="absolute z-10 mt-1 shadow-md">
-        {/* 캘린더 추가 시 캘린더 컴포넌트 추가 */}
-        <></>
+        <div className="relative">
+          <Calendar
+            currentDate={currentDate}
+            selectedDate={selectedDate}
+            navigateMonth={navigateMonth}
+            handleDateSelect={handleDateFilter}
+            isSameDay={isSameDay}
+            getDaysInMonth={getDaysInMonth}
+            getFirstDayOfMonth={getFirstDayOfMonth}
+            isDateDisabled={isDateDisabled}
+          />
+        </div>
       </Dropdown.Container>
     </Dropdown>
   );
@@ -159,13 +221,10 @@ const SocialFilterBar = ({ filter, filterDispatch }: FilterProps) => {
   return (
     <div className="flex justify-between">
       <div className="flex gap-2">
-        {/* 장르 필터 */}
         <GenreFilter filter={filter} filterDispatch={filterDispatch} />
-        {/* 날짜 필터 추가예정 */}
-        <DateFilter />
+        <DateFilter filter={filter} filterDispatch={filterDispatch} />
       </div>
 
-      {/* 참여자수, 모집마감순 정렬 필터 */}
       <SortByCapacityAndEndDate
         filter={filter}
         filterDispatch={filterDispatch}


### PR DESCRIPTION
## 이슈[185]

## PR요약
### 날짜 필터링 기능 구현 및 초기화 버튼 기능 구현

소셜 모임 목록 페이지에서 날짜별 필터링 기능을 추가하고, 선택된 날짜를 초기화할 수 있는 기능을 구현했습니다.
이를 통해 사용자가 특정 날짜의 모임만 필터링하여 볼 수 있으며, 필요시 쉽게 필터를 초기화할 수 있습니다.

### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 스타일 관련
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
1. 날짜 필터링 기능
   - 캘린더를 통한 날짜 선택 기능 구현
   - 선택된 날짜를 'yyyy-MM-dd' 형식으로 필터에 적용
   - 선택된 날짜가 버튼에 표시되도록 구현

2. 날짜 초기화 기능
   - RefreshCcw 아이콘을 사용한 초기화 버튼 추가
   - 날짜가 선택된 상태에서만 초기화 버튼이 표시되도록 구현
   - 초기화 버튼 클릭 시 필터 제거 및 '날짜 전체' 표시

### 구현결과

https://github.com/user-attachments/assets/5056ec2f-5243-49a6-a8c5-9fa24143e495

