### PR TITLE
Fix: 텍스트 에디터로 입력한 글(Summary, Content)을 불러왔을 때, 줄바꿈이 적용되지 않는 문제 수정

### DIFF
--- a/src/app/social/detail/[socialId]/StorySummary.tsx
+++ b/src/app/social/detail/[socialId]/StorySummary.tsx
@@ -73,7 +73,7 @@ const StorySummary = ({
         </div>
       ) : (
         <div
-          className="prose max-w-none"
+          className="prose rendered-html max-w-none"
           dangerouslySetInnerHTML={{ __html: extractionHtml }}
         />
       )}

--- a/src/components/common/TextEditor/TextEditor.tsx
+++ b/src/components/common/TextEditor/TextEditor.tsx
@@ -11,6 +11,7 @@ import EditorToolbar from '@/components/common/TextEditor/EditorToolbar';
 import { Plugin } from 'prosemirror-state';
 import { TextEditorProps } from '@/components/common/TextEditor/type';
 import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
+import getTextWithLineBreaks from '@/utils/getTextWithLineBreaks';
 
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
@@ -116,7 +117,8 @@ const TextEditor = forwardRef(
         editor
           ? {
               getHTML: () => editor.getHTML(),
-              getText: () => editor.getText(),
+              getText: () =>
+                getTextWithLineBreaks({ htmlString: editor.getHTML() }),
             }
           : {
               getHTML: () => '',

--- a/src/components/feature/library/ContentComponent.tsx
+++ b/src/components/feature/library/ContentComponent.tsx
@@ -1,13 +1,26 @@
 import React from 'react';
 import { DBContentResponse } from '@/types/dbStory';
+import getTextWithLineBreaks from '@/utils/getTextWithLineBreaks';
 const ContentComponent = ({ contents }: { contents: DBContentResponse[] }) => {
+  const isHtmlString = (str: string): boolean => {
+    const doc = new DOMParser().parseFromString(str, 'text/html');
+    return Array.from(doc.body.childNodes).some((node) => node.nodeType === 1);
+  };
+
   return (
-    <div className="text-md text-gray-600 md:text-base">
-      {contents?.map((contentItem: DBContentResponse) => (
-        <div className="mb-4" key={contentItem.content_id}>
-          {contentItem.content}
-        </div>
-      ))}
+    <div className="text-md whitespace-pre-line text-gray-600 md:text-base">
+      {contents?.map((contentItem) => {
+        const content = contentItem.content;
+        const isHtmlContent = isHtmlString(content);
+
+        return (
+          <div className="mb-4" key={contentItem.content_id}>
+            {isHtmlContent
+              ? getTextWithLineBreaks({ htmlString: content })
+              : content}
+          </div>
+        );
+      })}
     </div>
   );
 };

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -70,6 +70,12 @@
   height: 0;
 }
 
+.rendered-html p:empty::after {
+  content: '\A';
+  white-space: pre;
+  display: block;
+}
+
 blockquote {
   border-left: 4px solid #ccc;
   margin-left: 0;

--- a/src/utils/getTextWithLineBreaks.ts
+++ b/src/utils/getTextWithLineBreaks.ts
@@ -1,0 +1,17 @@
+interface GetTextWithLineBreaksParams {
+  htmlString: string;
+}
+
+const getTextWithLineBreaks = ({
+  htmlString,
+}: GetTextWithLineBreaksParams): string => {
+  return htmlString
+    .replace(/<p[^>]*>/gi, '')
+    .replace(/<\/p>/gi, '\n')
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/\r\n/g, '\n')
+    .replace(/\n{5,}/g, '\n\n\n\n')
+    .replace(/^\n+|\n+$/g, '');
+};
+
+export default getTextWithLineBreaks;


### PR DESCRIPTION
## PR요약
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 스타일 관련
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트



### 변경 사항
모임 상세 페이지의 `Summary`와 스토리 상세 페이지의 `StoryContent`에 텍스트 에디터로 입력한 줄바꿈이 적용될 수 있도록 하였습니다.

- html 문자열(객체)를 입력 받아 줄바꿈 처리된 순수한 문자열을 반환하는 `getTextWithLineBreaks` 함수 적용
- 소개글 영역에서 `dangerouslySetInnerHTML`로 HTML 문자열을 출력할 때, 줄바꿈이 이루어질 수 있도록, `rendered-html` 커스텀 클래스 적용
- 스토리 상세에서 컨텐츠를 불러올 땐 `isHtml`함수를 통해 HTML문자열인지, 순수 문자열인지를 체크하고 만약 HTML 문자열이라면 `getTextWithLineBreaks` 함수로 파싱을 진행한 뒤에 출력

HTML문자열 파싱 방식을 변경하면서 기존 `fix/#182-library-detail-html-rendering` 브랜치로 올린 PR은 종료하였습니다.