### PR TITLE
Fix: 모임 생성 직후 작성된 글이 존재하지 않을 때, 컨텐츠 작성이 불가능한 문제 수정

### DIFF
--- a/src/app/library/detail/[id]/_components/CreateContentModal.tsx
+++ b/src/app/library/detail/[id]/_components/CreateContentModal.tsx
@@ -44,7 +44,7 @@ const CreateContentModal = ({
       console.warn('유저 정보가 존재하지 않습니다.');
       return;
     }
-    if (lastContentData.status === 'PENDING') {
+    if (lastContentData?.status === 'PENDING') {
       alert('승인 대기 중인 글이 존재하여 등록할 수 없습니다.');
       return;
     }

--- a/src/app/library/detail/[id]/_components/WritableUserModal.tsx
+++ b/src/app/library/detail/[id]/_components/WritableUserModal.tsx
@@ -47,13 +47,15 @@ const WritableUserModal = ({
     }
   }, [approveUserData, currentUserId]);
 
-  if (lastContentData?.status === 'MERGED') {
+  if (!lastContentData || lastContentData?.status === 'MERGED') {
     return (
       <CreateStoryContentModal
         currentChapter={currentChapter}
         currentStoryId={currentStoryId}
         currentUserId={currentUserId}
-        lastContentData={lastContentData}
+        {...(lastContentData && {
+          lastContentData: lastContentData,
+        })}
       />
     );
   }

--- a/src/app/library/detail/[id]/_components/type.ts
+++ b/src/app/library/detail/[id]/_components/type.ts
@@ -13,5 +13,5 @@ export interface CreateContentModalProps {
   currentChapter: number;
   currentStoryId: string;
   currentUserId?: number;
-  lastContentData: DBContentResponse;
+  lastContentData?: DBContentResponse;
 }


### PR DESCRIPTION
## PR요약
<!---- PR제목은 [기능]: '제목"으로 작성해주세요 ex) Feat : 로그인/회원가입기능 폼구현. -->
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->




### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 스타일 관련
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트



### 변경 사항
스토리 상세 페이지에서 "컨텐츠 작성 UI"가 출력되는 조건을
기존에 `마지막 작성 컨텐츠가 MERGED일 때`뿐만 아니라,
`마지막 작성 컨텐츠가 존재하지 않을 때` 를 추가하여
모임 생성 초기에 컨텐츠가 존재하지 않은 상황에서도 `컨텐츠 작성 UI`가 출력되도록 수정했습니다
