### PR TITLE
Fix: 승인되지 않은 글이 스토리 상세 페이지에 출력되는 문제 수정 (MERGED 된 컨텐츠만 가져오도록 수정)

### DIFF
--- a/src/hooks/stories/useGetContent.ts
+++ b/src/hooks/stories/useGetContent.ts
@@ -6,5 +6,9 @@ export const useGetContent = ({ id, page, limit }: GetContentsProps) => {
   return useQuery({
     queryKey: ['contents', id, page],
     queryFn: () => getContents({ id, page, limit }),
+    select: (response) => ({
+      count: response.count,
+      data: response.data.filter((item) => item.status === 'MERGED'),
+    }),
   });
 };


### PR DESCRIPTION
## PR요약
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 스타일 관련
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트



### 변경 사항
`useQuery`의 `select`옵션을 사용하여
`useGetContent` 호출 시에 `status`가 `MERGED`인 데이터만 가져오도록 필터링하였습니다.
(서버에서 가져올 때부터 필터링을 할 수 있겠지만, `PENDING`인 컨텐츠를 하나 더 가져오는 성능 낭비가 크지 않다고 판단하여
일단은 전체를 가져오고 그 중에 `MERGED` 만 반환하도록 하였습니다.)
현재로써는 `PENDING` 상태인 컨텐츠가 필요할 경우 `useGetLastContent` 훅을 사용하면 됩니다.
차후에 두 요청을 하나로 줄일 수 있을 지 이야기해보면 좋을 것 같습니다.
