### PR TITLE
Feat: 승인 정원 이상일 때 자동 병합 기능

### DIFF
--- a/src/api/stories/api.ts
+++ b/src/api/stories/api.ts
@@ -139,6 +139,7 @@ export const updateContentMerge = async (storyId: string): Promise<void> => {
       .from('Contents')
       .select('content_id')
       .eq('story_id', storyId)
+      .eq('status', 'PENDING')
       .single();
     if (contentsError) {
       throw new Error(contentsError.message);

--- a/src/api/stories/api.ts
+++ b/src/api/stories/api.ts
@@ -161,8 +161,6 @@ export const updateContentMerge = async (storyId: string): Promise<void> => {
           status: 'MERGED',
         })
         .eq('story_id', storyId);
-    } else {
-      throw new Error('스토리 승인 기준 미달');
     }
   } catch (error) {
     throw new Error(error as string);

--- a/src/hooks/api/content-approvals/useApproveContent.ts
+++ b/src/hooks/api/content-approvals/useApproveContent.ts
@@ -1,4 +1,4 @@
-import { approveContent } from '@/api/stories/api';
+import { approveContent, updateContentMerge } from '@/api/stories/api';
 import { ApproveContentParams } from '@/api/stories/type';
 import { QUERY_KEY } from '@/constants/queryKey';
 import { DBContentApprovalResponse } from '@/types/dbStory';
@@ -28,6 +28,7 @@ const useApproveContent = ({
       console.error(error);
     },
     onSuccess: () => {
+      updateContentMerge(storyId);
       queryClient.invalidateQueries({
         queryKey: [QUERY_KEY.GET_LAST_CONTENT, storyId],
       });


### PR DESCRIPTION
## 이슈[198]

## PR요약
<!---- PR제목은 [기능]: '제목"으로 작성해주세요 ex) Feat : 로그인/회원가입기능 폼구현. -->
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 승인 정원 이상일 때만 자동 병합 기능



### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 스타일 관련
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트



### 변경 사항
<!---- ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. -->
- 승인 인원에 만족하는 마지막 승인시에 자동 병합 기능 추가했습니다.
- 데이터베이스에 우리가 생각한 로직과 다르게 저장된 내용들이 있어서 로직상에는 문제가 없어서도 에러가 발생하는 경우가 있었던 것 같습니다.
- ex) 한 스토리당 pending은 하나밖에 없는데 두개 이상인 경우





### 구현결과(사진첨부 선택)
(내용)
