### PR TITLE
Fix: 사용자 이름을 가져오는 요청에서 발생하는 multiple rows returned 에러를 수정

### DIFF
--- a/src/api/stories/api.ts
+++ b/src/api/stories/api.ts
@@ -220,10 +220,10 @@ export const getSocialParticipantsByDb = async (userId: number) => {
   const { data, error } = await instanceBaaS
     .from('story_collaborators')
     .select('user_name')
-    .eq('user_id', userId)
-    .single();
+    .eq('user_id', userId);
+
   if (error) {
     throw new Error(error.message);
   }
-  return data;
+  return data[0].user_name;
 };

--- a/src/app/library/detail/[id]/_components/WritableUserModal.tsx
+++ b/src/app/library/detail/[id]/_components/WritableUserModal.tsx
@@ -101,9 +101,7 @@ const WritableUserModal = ({
       <div className="mb-1 pt-12">
         {lastContentWroteUserName && (
           <h2 className="mb-2 text-3xl">
-            <span className="text-write-main">
-              {lastContentWroteUserName?.user_name}
-            </span>
+            <span className="text-write-main">{lastContentWroteUserName}</span>
             님이
             <br />
             등록한 글이 승인 대기 중입니다.

--- a/src/hooks/api/useGetSocialParticipantsByDb.ts
+++ b/src/hooks/api/useGetSocialParticipantsByDb.ts
@@ -7,10 +7,8 @@ interface UseGetSocialParticipantsByDbParams {
   userId?: number;
 }
 
-type UseGetSocialParticipantsByDbResponse = Pick<
-  DBStoryCollaboratorsResponse,
-  'user_name'
->;
+type UseGetSocialParticipantsByDbResponse =
+  DBStoryCollaboratorsResponse['user_name'];
 
 const useGetSocialParticipantsByDb = ({
   userId,


### PR DESCRIPTION
## PR요약




### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 스타일 관련
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트



### 변경 사항
```
{code: "PGRST116", details: "The result contains 2 rows", hint: null,…}
code
: 
"PGRST116"
details
: 
"The result contains 2 rows"
hint
: 
null
message
: 
"JSON object requested, multiple (or no) rows returned"
```
기존에 위와 같은 406 에러가 발생했는데 원인은 반환되는 결과가 정확히 1개일 때만 허용하는
Supabase의 `.single()` 메서드였습니다.
`single()`를 제거하여 에러를 해결하였고, 같은 `userId`에 해당하는 `user_name`이 객체형 배열로 값이 들어왔기에
그 중 0번 째 인덱스의 `user_name`을 반환하도록 하였습니다.
(하나의 `user_id`는 하나의 `user_name`과만 매칭되므로, 몇 번째 인덱스의 값을 가져와도 항상 결과는 똑같습니다.)
```
[{user_name: "HelloWorld"}, {user_name: "HelloWorld"}, { ... ]
```
`return data`일 때 위와 같이 반환되던 값을,
`return data[0].user_name`으로 변경하여 `HelloWorld`와 같은 하나의 문자열만 반환되도록 변경하였습니다.