### PR TITLE
Fix: 모임 참여에 성공했을 때, alert출력, UI 반영 적용

### DIFF
--- a/src/api/story-collaborators/api.ts
+++ b/src/api/story-collaborators/api.ts
@@ -4,9 +4,18 @@ import { CreateCollaboratorParams } from './type';
 
 export const createCollaborator = async (params: CreateCollaboratorParams) => {
   const { data, role } = params;
-  const response = await instanceBaaS.from(DB_PATH.STORY_COLLABORATORS).insert({
-    ...data,
-    role,
-  });
-  return response.data;
+  try {
+    const { data: response, error } = await instanceBaaS
+      .from(DB_PATH.STORY_COLLABORATORS)
+      .insert({
+        ...data,
+        role,
+      });
+    if (error) throw new Error(error.message);
+
+    return response;
+  } catch (error) {
+    console.error(error);
+    throw new Error('참여자 정보가 등록되지 못했습니다.');
+  }
 };

--- a/src/hooks/api/teams/useJoinTeam.tsx
+++ b/src/hooks/api/teams/useJoinTeam.tsx
@@ -60,6 +60,7 @@ const useJoinTeam = (params: UseJoinTeamParams) => {
       queryClient.invalidateQueries({
         queryKey: [QUERY_KEY.SOCIAL_PARTICIPANTS, socialId],
       });
+      setTimeout(() => alert('모임 참여에 성공했습니다.'), 0);
     },
   });
 };

--- a/src/hooks/api/teams/useParticipateCollaborator.ts
+++ b/src/hooks/api/teams/useParticipateCollaborator.ts
@@ -4,10 +4,12 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 interface useParticipateCollaboratorParams {
   socialId: number;
+  storyId?: string;
 }
 
 const useParticipateCollaborator = ({
   socialId,
+  storyId,
 }: useParticipateCollaboratorParams) => {
   const queryClient = useQueryClient();
   return useMutation({
@@ -18,6 +20,9 @@ const useParticipateCollaborator = ({
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: [QUERY_KEY.SOCIAL_PARTICIPANTS, socialId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEY.GET_USER_ROLE, storyId],
       });
     },
   });


### PR DESCRIPTION
## PR요약
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 스타일 관련
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트



### 변경 사항
`navigateStoryOrJoinTeam` 함수의 구조를 개선하였습니다.
중첩된 if문을 줄였고, `try catch` 문을 추가하여 모임 참여 요청에 대한 에러 제어를 가능하도록 하였습니다.

try 내부에서 비동기로 '모임 참여 요청'과 'Collaborators테이블에 사용자 등록'이 이루어질 수 있도록,
두 메서드를 `mutate()`에서 `mutateAsync()` 으로 변경하였습니다. 

'모임에 참여하시겠습니까?' '모임 참여에 성공했습니다' 같은 사용자가 응답 결과를 확인할 수 있는 alert 메시지를 추가하였고,
참여 성공 시에 `UserRole` 쿼리를 무효화하고, 부분 refetch 를 실행해서
권한에 따라 분기 처리 되는 '참여하기' 버튼이 곧바로 '스토리 이어쓰기' 버튼으로 변경되도록 하였습니다.

![We Write - Chrome 2025-06-10 12-02-24](https://github.com/user-attachments/assets/fa8c66a9-0e00-4cbc-90d3-e1df903b6ccd)

