### PR TITLE
Feat: 에디터를 통한 텍스트 작성 시에 글자 수 제한 적용

### DIFF
--- a/src/app/library/detail/[id]/_components/CreateContentModal.tsx
+++ b/src/app/library/detail/[id]/_components/CreateContentModal.tsx
@@ -15,6 +15,7 @@ const CreateContentModal = ({
   currentStoryId,
   currentUserId,
   lastContentData,
+  maxContentLength,
 }: CreateContentModalProps) => {
   const editorContentRef = useRef<TextEditorRef>(null);
   const { isOpen, closeModal } = useStoryModal();
@@ -96,10 +97,13 @@ const CreateContentModal = ({
       className="flex h-full w-full max-w-232 flex-col justify-center md:block md:h-auto md:w-fit"
     >
       <form onSubmit={handlePostStoryContent} className="mb-1 pt-12">
-        <div className="mb-6">
+        <div className="mb-2 px-2">
           <h2 className="mb-2 text-xl">이어질 이야기를 작성해주세요</h2>
           <p className="text-2xl font-semibold">
             현재 챕터 <span className="font-extrabold">{currentChapter}</span>
+          </p>
+          <p className="text-end text-gray-500">
+            글자 수 제한 : {maxContentLength}
           </p>
         </div>
         <TextEditor
@@ -107,6 +111,7 @@ const CreateContentModal = ({
           editorHeight="500px"
           initialContent={temporaryContent}
           useToolbarMenu={false}
+          maxContentLength={maxContentLength}
           className="min-h-110 md:min-w-180 lg:min-h-125 lg:min-w-220"
         />
         <div className="mt-6 flex justify-end gap-2">

--- a/src/app/library/detail/[id]/_components/WritableUserModal.tsx
+++ b/src/app/library/detail/[id]/_components/WritableUserModal.tsx
@@ -18,6 +18,7 @@ const WritableUserModal = ({
   currentUserId,
   approvalPeriod,
   approvedCount,
+  maxContentLength,
 }: WritableUserModalProps) => {
   const { isOpen, closeModal } = useStoryModal();
   const [isUserApproved, setIsUserApproved] = useState(false);
@@ -56,6 +57,7 @@ const WritableUserModal = ({
         {...(lastContentData && {
           lastContentData: lastContentData,
         })}
+        maxContentLength={maxContentLength}
       />
     );
   }

--- a/src/app/library/detail/[id]/_components/type.ts
+++ b/src/app/library/detail/[id]/_components/type.ts
@@ -7,6 +7,7 @@ export interface WritableUserModalProps {
   currentUserId?: number;
   approvalPeriod: number;
   approvedCount: number;
+  maxContentLength: number;
 }
 
 export interface CreateContentModalProps {
@@ -14,4 +15,5 @@ export interface CreateContentModalProps {
   currentStoryId: string;
   currentUserId?: number;
   lastContentData?: DBContentResponse;
+  maxContentLength: number;
 }

--- a/src/app/library/detail/[id]/page.tsx
+++ b/src/app/library/detail/[id]/page.tsx
@@ -71,6 +71,7 @@ const StoryDetailPage = () => {
               {...(myInfo && { currentUserId: myInfo.id })}
               approvalPeriod={story?.approval_period ?? 0}
               approvedCount={story?.approved_count ?? 0}
+              maxContentLength={story?.max_length}
             />
           </>
         );

--- a/src/components/common/TextEditor/TextEditor.tsx
+++ b/src/components/common/TextEditor/TextEditor.tsx
@@ -19,6 +19,8 @@ import {
 } from 'react';
 import getTextWithLineBreaks from '@/utils/getTextWithLineBreaks';
 
+const DEFAULT_STRING_MAX_LENGHT = 2000;
+
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
     fontSize: {
@@ -96,7 +98,7 @@ const StringLimit = Extension.create({
 
   addOptions() {
     return {
-      limit: 5000,
+      limit: DEFAULT_STRING_MAX_LENGHT,
     };
   },
 
@@ -127,7 +129,7 @@ const TextEditor = forwardRef(
       isReadOnly = false,
       useToolbarMenu = true,
       initialContent,
-      maxContentLength = 2000,
+      maxContentLength = DEFAULT_STRING_MAX_LENGHT,
     }: TextEditorProps,
     ref
   ) => {

--- a/src/components/common/TextEditor/type.ts
+++ b/src/components/common/TextEditor/type.ts
@@ -10,6 +10,7 @@ export interface TextEditorProps {
   isReadOnly?: boolean;
   useToolbarMenu?: boolean;
   initialContent?: string;
+  maxContentLength?: number;
 }
 
 export interface HandleFontSizeChangeParams {


### PR DESCRIPTION
## PR요약
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 스타일 관련
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트



### 변경 사항
`StringLimit`라는 커스텀 Extension을 만들어서 텍스트 에디터 내부의 글자 수 제한을 적용하였습니다.
컨텐츠 작성 시에는 모임장이 설정한 제한 글자 수가 적용되며,
소개글 작성 시에는 기본 값인 최대 2000자 제한이 적용됩니다.

```
{hasReachedLimit && (
  <p className="pr-4 text-gray-500">최대 글자 수에 도달하였습니다.</p>
)}
```
위와 같은 HelperText를 적용하여, 사용자에게 글자 상한선 도달 여부를 알리도록 하였습니다.
