### PR TITLE
fix: 컨텐츠 등록 직후에 승인 인원수가 0이 아닌 1로 표시되는 문제 수정

### DIFF
--- a/src/app/library/detail/[id]/_components/WritableUserModal.tsx
+++ b/src/app/library/detail/[id]/_components/WritableUserModal.tsx
@@ -37,15 +37,15 @@ const WritableUserModal = ({
   });
 
   useEffect(() => {
-    if (Array.isArray(approveUserData)) {
-      setTempApprovedCount(approveUserData.length);
+    if (!approveUserData) return;
 
-      if (currentUserId) {
-        const hasApproved = approveUserData.some(
-          (item) => item.user_id === currentUserId
-        );
-        setIsUserApproved(hasApproved);
-      }
+    setTempApprovedCount(approveUserData.length);
+
+    if (currentUserId) {
+      const hasApproved = approveUserData.some(
+        (item) => item.user_id === currentUserId
+      );
+      setIsUserApproved(hasApproved);
     }
   }, [approveUserData, currentUserId]);
 

--- a/src/app/library/detail/[id]/_components/WritableUserModal.tsx
+++ b/src/app/library/detail/[id]/_components/WritableUserModal.tsx
@@ -35,15 +35,17 @@ const WritableUserModal = ({
     storyId: currentStoryId,
     contentId: lastContentData?.content_id,
   });
+
   useEffect(() => {
-    if (approveUserData?.length) {
-      setTempApprovedCount(approveUserData?.length);
-    }
-    if (approveUserData && currentUserId) {
-      const hasApproved = approveUserData.some(
-        (item) => item.user_id === currentUserId
-      );
-      setIsUserApproved(hasApproved);
+    if (Array.isArray(approveUserData)) {
+      setTempApprovedCount(approveUserData.length);
+
+      if (currentUserId) {
+        const hasApproved = approveUserData.some(
+          (item) => item.user_id === currentUserId
+        );
+        setIsUserApproved(hasApproved);
+      }
     }
   }, [approveUserData, currentUserId]);
 


### PR DESCRIPTION
## PR요약
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 스타일 관련
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트



### 변경 사항
```
if (approveUserData?.length) {
  setTempApprovedCount(approveUserData?.length);
}
if (approveUserData && currentUserId) {
```
기존 useEffect 내부에서 승인 인원 수를 업데이트하는 로직은
`approveUserData`로 빈 배열이 들어오면 조건 검사에 실패하여 `tempApprovedCount` 상태를 업데이트하지 않았습니다.
그래서 빈 배열이 들어와도 승인 인원 수를 0으로 업데이트하지 못하는 문제가 있었습니다.

```
if (Array.isArray(approveUserData)) {
  setTempApprovedCount(approveUserData.length);
```
변경된 로직은 `approveUserData`가 배열인지 아닌지(undefined인지)만을 검사하여,
배열이라면 내부가 비어있는 여부와는 관계 없이 항상 `tempApprovedCount`를 업데이트하므로
API 응답의 상태를 보다 잘 반영할 수 있게 하였습니다.

현재 개발 환경 테스트에서는 해당 '컨텐츠 등록 직후 승인인원 1 표시' 이슈가 발견되지 않고 있는데
혹시 다시 동일한 문제가 발생하거나 승인 인원 표시 관련한 다른 문제가 발생하면 말씀 부탁드립니다!