### PR TITLE
fix: 모집 정원이 채워졌을 때 이미 모임에 속한 사용자의 '스토리 이어쓰기' 버튼이 비활성화되는 문제 수정

### DIFF
--- a/src/components/common/Card/DetailCard.tsx
+++ b/src/components/common/Card/DetailCard.tsx
@@ -19,9 +19,11 @@ const DetailCard = ({
   const startDate = duration.startDate ? new Date(duration.startDate) : null;
   const endDate = duration.endDate ? new Date(duration.endDate) : null;
   const isButtonActivate =
-    textContent.capacity !== null && textContent.participantCount !== null
-      ? textContent.capacity > textContent.participantCount
-      : false;
+    teamUserRole === 'GUEST'
+      ? textContent.capacity !== null &&
+        textContent.participantCount !== null &&
+        textContent.capacity > textContent.participantCount
+      : teamUserRole === 'MEMBER' || teamUserRole === 'LEADER';
 
   const getParticipationButtonLabel = ({
     paramTeamUserRole,
@@ -98,7 +100,7 @@ const DetailCard = ({
           type="button"
           isDisabled={!isButtonActivate}
           onClick={() => handleButtonClick(teamUserRole)}
-          className="flex-1 font-semibold"
+          className={`flex-1 font-semibold ${!isButtonActivate && 'cursor-not-allowed'}`}
         >
           {isCardDataLoading
             ? '정보를 불러오는 중입니다.'


### PR DESCRIPTION
## PR요약

### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 스타일 관련
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트



### 변경 사항
`isButtonActivate`의 조건 설정
**기존** : `capacity`와 `participantCount`를 비교해서 `capacity`가 더 클때만 활성화

**변경** : 추가적으로 현재 사용자의 권한을 검사하여, `GUEST`일 경우 `capacity`가
더 클 때만(모집 정원이 채워지지 않았을 때만) 활성화,
`MEMBER`또는 `LEADER` 일 때는 항상 활성화
