### PR TITLE
Fix/#211: 모임 참여 성공 및 로그아웃 시에 모임 정보가 갱신(최신화)되도록 수정

### DIFF
--- a/src/hooks/api/teams/useJoinTeam.tsx
+++ b/src/hooks/api/teams/useJoinTeam.tsx
@@ -60,6 +60,9 @@ const useJoinTeam = (params: UseJoinTeamParams) => {
       queryClient.invalidateQueries({
         queryKey: [QUERY_KEY.SOCIAL_PARTICIPANTS, socialId],
       });
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEY.SOCIAL_DETAIL, socialId],
+      });
       setTimeout(() => alert('모임 참여에 성공했습니다.'), 0);
     },
   });

--- a/src/hooks/api/users/usePostSignout.ts
+++ b/src/hooks/api/users/usePostSignout.ts
@@ -10,6 +10,9 @@ export const usePostSignout = () => {
     onSuccess: () => {
       deleteCookie('accessToken');
       queryClient.removeQueries({ queryKey: [QUERY_KEY.MY_INFO] });
+      queryClient.removeQueries({
+        queryKey: [QUERY_KEY.GET_USER_ROLE],
+      });
     },
     onError: (error) => {
       console.error(error);


### PR DESCRIPTION
## PR요약

### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 스타일 관련
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트



### 변경 사항
- 모임 참여(joinTeam) 성공 시에 모임 상세 쿼리를 무효화하고 refetch하도록 설정하였습니다.
- 로그 아웃(signOut) 성공 시에 유저 권한 쿼리를 제거하도록 설정하였습니다.

기존에 모임 참여 버튼의 활성화 여부를 검증할 때,
모임 상세에서 가져온 `capacity`와 `participantCount`를 비교하였기에
참여에 성공했을 때 모임 상세 정보를 새로 불러와 최신화된 `capacity`와 `participantCount` 데이터가 적용될 수 있도록 하였습니다.

사용자 권한을 가져온 쿼리 데이터가 캐싱 되어 로그 아웃 이후에도 계속 `MEMBER` 또는 `LEADER`로 데이터가 남아있는
문제를 해결하기 위해서 유저 권한 쿼리를 제거하도록 하였습니다.
