### PR TITLE
Fix/#232: 모임 참여 버튼 클릭 시에 서로 다른 alert 가 연달아 출력되는 문제 수정

### DIFF
--- a/src/app/social/detail/[socialId]/_components/SocialOverView.tsx
+++ b/src/app/social/detail/[socialId]/_components/SocialOverView.tsx
@@ -63,6 +63,7 @@ const SocialOverView = ({
     if (!currentUserId || !currentUserName) {
       alert('로그인이 필요한 서비스입니다.');
       router.push('/auths/signin');
+      return;
     }
 
     const joinTeamConfirmed = window.confirm('모임에 참여하시겠습니까?');
@@ -80,6 +81,8 @@ const SocialOverView = ({
         },
         role: TEAM_USER_ROLE.MEMBER,
       });
+
+      alert('모임 참여에 성공했습니다.');
     } catch (error) {
       console.error('모임 참여 실패 : ', error);
       alert('오류가 발생하여 모임 참여에 실패하였습니다.');

--- a/src/hooks/api/supabase/story-collaborators/useJoinTeam.ts
+++ b/src/hooks/api/supabase/story-collaborators/useJoinTeam.ts
@@ -60,7 +60,6 @@ const useJoinTeam = (params: UseJoinTeamParams) => {
       queryClient.invalidateQueries({
         queryKey: [QUERY_KEY.SOCIAL_PARTICIPANTS, socialId],
       });
-      setTimeout(() => alert('모임 참여에 성공했습니다.'), 0);
     },
   });
 };


### PR DESCRIPTION
## 변경 사항
```
try {
  await joinTeam();

  await insertNewCollaborator({
    data: {
      story_id: currentStoryId,
      user_id: currentUserId!,
      user_name: currentUserName!,
      joined_at: new Date().toISOString(),
    },
    role: TEAM_USER_ROLE.MEMBER,
  });
```
기존에 모임 참여 버튼을 클릭하면 위와 같이 비동기적으로 요청이 보내졌고,
모임 참여에 대한 성공 alert는 `joinTeam` Mutation내부의 onSuccess옵션으로 설정되어 있었습니다.
그래서 `joinTeam`은 성공하고, `insertNewCollaborator`는 실패하면
모임 참여 성공 alert가 뜨면서 바로 catch문의 모임 참여 실패 alert가 출력되는 문제가 있었습니다.

Mutation 내부의 alert메시지를 try 문으로 옮겨서 두 요청 모두 성공했을 때만 출력되도록 변경하였습니다.

```
if (!currentUserId || !currentUserName) {
  alert('로그인이 필요한 서비스입니다.');
  router.push('/auths/signin');
  return;
}

const joinTeamConfirmed = window.confirm('모임에 참여하시겠습니까?');
```
또한 기존에 조건문 내부에 return 문이 존재하지 않아서
alert('로그인이 필요한 서비스입니다.') -> confirm('모임에 참여하시겠습니까?') 가 연이어서 출력되는 문제가 있었는데
return문을 추가하여서 해결했습니다.