### PR TITLE
Fix/#235: 텍스트 에디터의 아무 위치나 클릭해도 커서(focus)가 활성화되도록 수정

### DIFF
--- a/src/components/common/TextEditor/TextEditor.tsx
+++ b/src/components/common/TextEditor/TextEditor.tsx
@@ -195,6 +195,11 @@ const TextEditor = forwardRef(
           ref={editorContentRef}
           editor={editor}
           className={`mt-2 overflow-y-auto`}
+          onClick={() => {
+            if (!editor?.isFocused) {
+              editor?.commands.focus();
+            }
+          }}
           style={{
             height:
               !isReadOnly && useToolbarMenu

--- a/src/components/common/TextEditor/TextEditor.tsx
+++ b/src/components/common/TextEditor/TextEditor.tsx
@@ -23,6 +23,7 @@ import {
 import getTextWithLineBreaks from '@/utils/getTextWithLineBreaks';
 
 const DEFAULT_STRING_MAX_LENGHT = 2000;
+const EDITOR_TOOLBAR_HEIGHT = '20px';
 
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
@@ -188,12 +189,15 @@ const TextEditor = forwardRef(
       editorHeight,
       isReadOnly,
       useToolbarMenu,
-    }: EditorContainerHeightParams) => ({
-      height:
-        !isReadOnly && useToolbarMenu
-          ? `calc(${editorHeight} - 20px)`
-          : editorHeight,
-    });
+    }: EditorContainerHeightParams) => {
+      const isContainToolbar = !isReadOnly && useToolbarMenu;
+
+      const height = isContainToolbar
+        ? `calc(${editorHeight} - ${EDITOR_TOOLBAR_HEIGHT})`
+        : editorHeight;
+
+      return { height };
+    };
 
     useEffect(() => {
       const proseMirrorEl = editorContentRef.current?.querySelector(

--- a/src/components/common/TextEditor/TextEditor.tsx
+++ b/src/components/common/TextEditor/TextEditor.tsx
@@ -174,8 +174,13 @@ const TextEditor = forwardRef(
     );
 
     const handleEditorFocus = (editor: Editor | null) => () => {
-      if (!editor?.isFocused) {
-        editor?.commands.focus();
+      if (!editor) {
+        console.warn('editor가 존재하지 않습니다.');
+        return;
+      }
+
+      if (!editor.isFocused) {
+        editor.commands.focus();
       }
     };
 

--- a/src/components/common/TextEditor/TextEditor.tsx
+++ b/src/components/common/TextEditor/TextEditor.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEditor, EditorContent } from '@tiptap/react';
-import { Extension } from '@tiptap/core';
+import { Editor, Extension } from '@tiptap/core';
 import StarterKit from '@tiptap/starter-kit';
 import TextStyle from '@tiptap/extension-text-style';
 import Color from '@tiptap/extension-color';
@@ -9,7 +9,10 @@ import TextAlign from '@tiptap/extension-text-align';
 import Blockquote from '@tiptap/extension-blockquote';
 import EditorToolbar from '@/components/common/TextEditor/EditorToolbar';
 import { Plugin } from 'prosemirror-state';
-import { TextEditorProps } from '@/components/common/TextEditor/type';
+import {
+  EditorContainerHeightParams,
+  TextEditorProps,
+} from '@/components/common/TextEditor/type';
 import {
   forwardRef,
   useEffect,
@@ -170,6 +173,23 @@ const TextEditor = forwardRef(
       [editor]
     );
 
+    const handleEditorFocus = (editor: Editor | null) => () => {
+      if (!editor?.isFocused) {
+        editor?.commands.focus();
+      }
+    };
+
+    const editorContainerHeight = ({
+      editorHeight,
+      isReadOnly,
+      useToolbarMenu,
+    }: EditorContainerHeightParams) => ({
+      height:
+        !isReadOnly && useToolbarMenu
+          ? `calc(${editorHeight} - 20px)`
+          : editorHeight,
+    });
+
     useEffect(() => {
       const proseMirrorEl = editorContentRef.current?.querySelector(
         '.ProseMirror'
@@ -195,17 +215,12 @@ const TextEditor = forwardRef(
           ref={editorContentRef}
           editor={editor}
           className={`mt-2 overflow-y-auto`}
-          onClick={() => {
-            if (!editor?.isFocused) {
-              editor?.commands.focus();
-            }
-          }}
-          style={{
-            height:
-              !isReadOnly && useToolbarMenu
-                ? `calc(${editorHeight} - 20px)`
-                : editorHeight,
-          }}
+          onClick={handleEditorFocus(editor)}
+          style={editorContainerHeight({
+            editorHeight,
+            isReadOnly,
+            useToolbarMenu,
+          })}
         />
         {hasReachedLimit && (
           <p className="pr-4 text-gray-500">최대 글자 수에 도달하였습니다.</p>

--- a/src/components/common/TextEditor/type.ts
+++ b/src/components/common/TextEditor/type.ts
@@ -26,3 +26,9 @@ export interface HandleChangeTextAlignParams {
 export interface HandleMarkChangeParams {
   mark: 'bold' | 'italic' | 'blockquote';
 }
+
+export interface EditorContainerHeightParams {
+  editorHeight: string;
+  isReadOnly: boolean;
+  useToolbarMenu: boolean;
+}


### PR DESCRIPTION
## 변경 사항
기존에 TipTap 에디터 내부에서 글을 쓰는 실제 영역(.ProseMirror)이 작기 때문에
전체 에디터 컨테이너를 클릭해도 커서가 활성화되지 않는 문제가 있었습니다.

포커스 가능한 영역을 `<EditorContent />` 전체로 확대하여 해당 문제를 해결했습니다.
```
onClick={() => {
  if (!editor?.isFocused) {
    editor.commands.focus();
  }
}}
```

인라인으로 적용된 onClick 이벤트 핸들러와 style속성을 외부 함수로 분리하였습니다.