### PR TITLE
Fix/#238: 마이페이지 → 내가 만든 모임에서 모임 탈퇴하기가 불가능하도록 변경

### DIFF
--- a/src/components/common/Card/ListCard.tsx
+++ b/src/components/common/Card/ListCard.tsx
@@ -10,6 +10,7 @@ import { format } from 'date-fns';
 import { Person } from '@public/assets/icons';
 
 const ListCard = ({
+  teamUserRole,
   pageId,
   image,
   chip,
@@ -30,6 +31,7 @@ const ListCard = ({
     if (isCompletedStory) {
       return '스토리 보러가기';
     }
+
     return '모임 탈퇴하기';
   };
 
@@ -102,20 +104,22 @@ const ListCard = ({
             </div>
           )}
         </div>
-        <Button
-          type="button"
-          onClick={handleButtonClick}
-          isDisabled={isCardDataLoading}
-          color="custom"
-          size="custom"
-          className={listCardButtonStyle}
-        >
-          {isCardDataLoading
-            ? '정보를 불러오는 중입니다'
-            : getListCardButtonLabel({
-                isCompletedStory: isCompletedStory,
-              })}
-        </Button>
+        {teamUserRole === 'MEMBER' && (
+          <Button
+            type="button"
+            onClick={handleButtonClick}
+            isDisabled={isCardDataLoading}
+            color="custom"
+            size="custom"
+            className={listCardButtonStyle}
+          >
+            {isCardDataLoading
+              ? '정보를 불러오는 중입니다'
+              : getListCardButtonLabel({
+                  isCompletedStory: isCompletedStory,
+                })}
+          </Button>
+        )}
       </div>
     </article>
   );


### PR DESCRIPTION
## 변경 사항
- 리더권한이 탈퇴했을 때의 시스템이 없는 상태(권한 관련)
- 마이 페이지에서 내가 만든 모임에서는 탈퇴하기 버튼이 보이지않게 변경했습니다.
- 모임장이 모임을 나갈 때를 대비한 기능이 필요할수도 있을 것 같습니다.
## 구현결과(사진첨부 선택)
![image](https://github.com/user-attachments/assets/5d206887-5ea1-4996-aea7-028529aa17cd)
