### PR TITLE
Fix/#222: 마이페이지 내 모임 탈퇴시 DB에서 참여자가 삭제되게 api 및 기능 추가

### DIFF
--- a/src/api/mypage/api.ts
+++ b/src/api/mypage/api.ts
@@ -6,6 +6,7 @@ import {
 } from './type';
 import instance from '@/api/instance';
 import { getFilterParams } from '@/utils/getFilterParams';
+import instanceBaaS from '@/api/instanceBaaS';
 
 export const getJoinedSocialList = async ({
   limit = 12,
@@ -24,6 +25,27 @@ export const getJoinedSocialList = async ({
   } catch (error) {
     throw error;
   }
+};
+
+export const getStoryBySocialId = async (socialId: string) => {
+  const { data, error } = await instanceBaaS
+    .from('Stories')
+    .select('*')
+    .eq('social_id', socialId)
+    .maybeSingle();
+  if (error) throw new Error(error.message);
+  if (!data) return;
+  return data.story_id;
+};
+
+export const getCollaboratorsByStoryId = async (storyId: string) => {
+  const { data, error } = await instanceBaaS
+    .from('story_collaborators')
+    .select('*')
+    .eq('story_id', storyId);
+
+  if (error) throw new Error(error.message);
+  return data;
 };
 
 export const leaveJoinSocial = async ({ id }: leaveJoinSocialRequest) => {

--- a/src/api/mypage/api.ts
+++ b/src/api/mypage/api.ts
@@ -48,6 +48,19 @@ export const getCollaboratorsByStoryId = async (storyId: string) => {
   return data;
 };
 
+export const deleteCollaboratorFromSocial = async (
+  userId: number,
+  storyId: string
+) => {
+  const { data, error } = await instanceBaaS
+    .from('story_collaborators')
+    .delete()
+    .match({ user_id: userId, story_id: storyId });
+
+  if (error) throw new Error(error.message);
+  return data;
+};
+
 export const leaveJoinSocial = async ({ id }: leaveJoinSocialRequest) => {
   try {
     const response = await instance.delete(API_PATH.SOCIAL + `/${id}/leave`);
@@ -57,6 +70,7 @@ export const leaveJoinSocial = async ({ id }: leaveJoinSocialRequest) => {
   }
 };
 
+// TODO: 달램 api 모임장의 모임 삭제 기능 (필요 없을시 지워도됨)
 export const cancelJoinSocial = async ({ id }: leaveJoinSocialRequest) => {
   try {
     const response = await instance.put(API_PATH.SOCIAL + `/${id}/cancel`);

--- a/src/app/mypage/mySocial/MySocialList.tsx
+++ b/src/app/mypage/mySocial/MySocialList.tsx
@@ -5,7 +5,7 @@ import SocialListCards from '@/app/mypage/mySocial/SocialListCards';
 import TabMenu from '@/app/mypage/mySocial/TabMenu';
 import { TabType } from '@/app/mypage/mySocial/type';
 import Observer from '@/components/common/Observer/Observer';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useMySocialList } from '@/hooks/mypage/useMySocialList';
 import { useAuth } from '@/providers/auth-provider/AuthProvider.client';
 
@@ -22,6 +22,12 @@ const MySocialList = () => {
     isLoading: isSocialListLoading,
     refetch,
   } = useMySocialList(activeTab, String(userId));
+
+  useEffect(() => {
+    if (userId) {
+      refetch();
+    }
+  }, [userId, activeTab, refetch]);
 
   const handleTabChange = (tab: TabType) => {
     setActiveTab(tab);

--- a/src/app/mypage/mySocial/SocialCardItem.tsx
+++ b/src/app/mypage/mySocial/SocialCardItem.tsx
@@ -1,0 +1,98 @@
+import { cancelJoinSocial, leaveJoinSocial } from '@/api/mypage/api';
+import { SocialListCardsProps } from '@/app/mypage/mySocial/type';
+import ListCard from '@/components/common/Card/ListCard';
+import { SOCIAL_ACTION_MESSAGES } from '@/constants/messages';
+import useCollaboratorList from '@/hooks/mypage/useCollaboratorList';
+import convertLocationToGenre from '@/utils/convertLocationToGenre';
+import { useRouter } from 'next/navigation';
+
+const SocialCardItem = ({
+  item,
+  activeTab,
+  refetch,
+}: {
+  item: SocialListCardsProps['list'][0];
+  activeTab: string;
+  refetch: () => void;
+}) => {
+  const router = useRouter();
+  const nowDate = new Date().toISOString();
+  const isStoryCompleted = (registrationEndDate: string) =>
+    registrationEndDate < nowDate;
+  const { data: collaborator } = useCollaboratorList(item.id);
+  const collaboratorCount = collaborator?.length || 0;
+
+  const handleQuitSocial = async (id: string) => {
+    const isJoined = activeTab === 'joined';
+
+    const messages = {
+      confirm: isJoined
+        ? SOCIAL_ACTION_MESSAGES.confirm.exit
+        : SOCIAL_ACTION_MESSAGES.confirm.delete,
+      success: isJoined
+        ? SOCIAL_ACTION_MESSAGES.success.exit
+        : SOCIAL_ACTION_MESSAGES.success.delete,
+    };
+    const action = isJoined ? leaveJoinSocial : cancelJoinSocial;
+
+    try {
+      const confirmed = window.confirm(messages.confirm);
+      if (!confirmed) return;
+
+      await action({ id });
+      alert(messages.success);
+      refetch();
+    } catch (error) {
+      console.error(error);
+      throw new Error('모임 취소 실패');
+    }
+  };
+
+  const handleCardButtonClick = ({
+    id,
+    registrationEnd,
+  }: {
+    id: string;
+    registrationEnd: string;
+  }) => {
+    if (isStoryCompleted(registrationEnd)) {
+      router.push(`/social/detail/${id}`);
+    }
+    handleQuitSocial(id);
+  };
+
+  return (
+    <div key={`${activeTab}-${item.id}`} className="truncate py-6">
+      <ListCard
+        teamUserRole={activeTab === 'created' ? 'LEADER' : 'MEMBER'}
+        pageId={item.id}
+        image={{
+          src:
+            item.image ||
+            'https://inabooth.io/_next/image?url=https%3A%2F%2Fd19bi7owzxc0m2.cloudfront.net%2Fprod%2Fcharacter_files%2FRwH7fLwSHwA4_e2s354f2.webp&w=3840&q=75',
+          alt: item.name || '섬네일 이미지',
+        }}
+        chip
+        textContent={{
+          title: item.name || '제목 없음',
+          genre:
+            convertLocationToGenre({ location: item.location }) || '장르 없음',
+          participantCount: collaboratorCount ?? 0,
+          capacity: item.capacity || 0,
+        }}
+        endDate={item.registrationEnd}
+        isCardDataLoading={false}
+        isCompletedStory={isStoryCompleted(item.registrationEnd)}
+        isCanceled={false}
+        handleButtonClick={() => {
+          handleCardButtonClick({
+            id: item.id,
+            registrationEnd: item.registrationEnd,
+          });
+        }}
+      />
+    </div>
+  );
+};
+
+export default SocialCardItem;

--- a/src/app/mypage/mySocial/SocialListCards.tsx
+++ b/src/app/mypage/mySocial/SocialListCards.tsx
@@ -12,8 +12,9 @@ const SocialListCards = ({
   refetch,
 }: SocialListCardsProps) => {
   const router = useRouter();
-  const todayDate = new Date().toISOString();
-  const isStoryCompleted = (endDate: string) => todayDate >= endDate;
+  const nowDate = new Date().toISOString();
+  const isStoryCompleted = (registrationEndDate: string) =>
+    registrationEndDate < nowDate;
 
   const handleQuitSocial = async (id: string) => {
     const isJoined = activeTab === 'joined';

--- a/src/app/mypage/mySocial/SocialListCards.tsx
+++ b/src/app/mypage/mySocial/SocialListCards.tsx
@@ -1,83 +1,17 @@
-'use client';
+import SocialCardItem from "@/app/mypage/mySocial/SocialCardItem";
+import { SocialListCardsProps } from "@/app/mypage/mySocial/type";
 
-import { cancelJoinSocial, leaveJoinSocial } from '@/api/mypage/api';
-import { convertLocationToGenre } from '@/utils/convertLocationToGenre';
-import { SocialListCardsProps } from '@/app/mypage/mySocial/type';
-import ListCard from '@/components/common/Card/ListCard';
-import { useRouter } from 'next/navigation';
-
-const SocialListCards = ({
-  list,
-  activeTab,
-  refetch,
-}: SocialListCardsProps) => {
-  const router = useRouter();
-  const nowDate = new Date().toISOString();
-  const isStoryCompleted = (registrationEndDate: string) =>
-    registrationEndDate < nowDate;
-
-  const handleQuitSocial = async (id: string) => {
-    const isJoined = activeTab === 'joined';
-
-    const messages = {
-      confirm: isJoined
-        ? '정말 모임을 나가시겠습니까?'
-        : '정말 모임을 삭제 하시겠습니까?',
-      success: isJoined
-        ? '모임 나가기가 완료되었습니다.'
-        : '모임 삭제가 완료되었습니다.',
-    };
-
-    const action = isJoined ? leaveJoinSocial : cancelJoinSocial;
-
-    try {
-      const confirmed = window.confirm(messages.confirm);
-      if (!confirmed) return;
-
-      await action({ id });
-      alert(messages.success);
-      refetch();
-    } catch (error) {
-      console.error(error);
-      throw new Error('모임 취소 실패');
-    }
-  };
-
+const SocialListCards = ({ list, activeTab, refetch }: SocialListCardsProps) => {
   return (
     <>
-      {list.map((item) => {
-        return (
-          <div key={`${activeTab}-${item.id}`} className="truncate py-6">
-            <ListCard
-              teamUserRole={activeTab === 'created' ? 'LEADER' : 'MEMBER'}
-              pageId={item.id || ''}
-              image={{
-                src: item.image || '',
-                alt: item.name || '섬네일 이미지',
-              }}
-              chip
-              textContent={{
-                title: item.name || '',
-                genre:
-                  convertLocationToGenre({ location: item.location }) ||
-                  '장르 없음',
-                participantCount: item.participantCount || 0,
-                capacity: item.capacity || 0,
-              }}
-              endDate={item.registrationEnd || ''}
-              isCardDataLoading={false}
-              isCompletedStory={isStoryCompleted(item.registrationEnd)}
-              isCanceled={false}
-              handleButtonClick={() => {
-                if (isStoryCompleted(item.registrationEnd)) {
-                  router.push(`/social/detail/${item.id}`);
-                }
-                handleQuitSocial(item.id);
-              }}
-            />
-          </div>
-        );
-      })}
+      {list.map((item) => (
+        <SocialCardItem
+          key={`${activeTab}-${item.id}`}
+          item={item}
+          activeTab={activeTab}
+          refetch={refetch}
+        />
+      ))}
     </>
   );
 };

--- a/src/app/mypage/mySocial/type.ts
+++ b/src/app/mypage/mySocial/type.ts
@@ -15,3 +15,9 @@ export interface SocialListCardsProps {
   activeTab: TabType;
   refetch: () => void;
 }
+
+export interface SocialCardItemProps {
+  item: SocialListCardsProps['list'][0];
+  activeTab: string;
+  refetch: () => void;
+}

--- a/src/constants/messages.ts
+++ b/src/constants/messages.ts
@@ -1,0 +1,10 @@
+export const SOCIAL_ACTION_MESSAGES = {
+  confirm: {
+    exit: '정말 모임을 나가시겠습니까?',
+    delete: '정말 모임을 삭제하시겠습니까?',
+  },
+  success: {
+    exit: '모임 나가기가 완료되었습니다.',
+    delete: '모임 삭제가 완료되었습니다.',
+  },
+};

--- a/src/hooks/mypage/useCollaboratorList.ts
+++ b/src/hooks/mypage/useCollaboratorList.ts
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query';
+import {
+  getStoryBySocialId,
+  getCollaboratorsByStoryId,
+} from '@/api/mypage/api';
+
+const useCollaboratorList = (socialId: string) => {
+  return useQuery({
+    queryKey: ['collaboratorUserIds', socialId],
+    queryFn: async () => {
+      const storyId = await getStoryBySocialId(socialId);
+      if (!storyId) return [];
+
+      const collaborators = await getCollaboratorsByStoryId(storyId);
+
+      // user_id 기준으로 중복 제거된 배열 반환
+      const uniqueUserIds = Array.from(
+        new Set(collaborators.map((item) => item.user_id))
+      );
+
+      return uniqueUserIds;
+    },
+  });
+};
+
+export default useCollaboratorList;


### PR DESCRIPTION
## 변경 사항
- 모임참여자 삭제하는 api 추가
- 모임 탈퇴시 DB에서 해당 참여자 삭제
- 모임찾기에서 모임 참여시 마이페이지에 바로 적용되지 않아 refetch추가
- 내가 만든 모임 모임 바로 가기 버튼으로 변경 (삭제 기능 제거)

## 구현결과(사진첨부 선택)
[모임 삭제 후 적용]
![1](https://github.com/user-attachments/assets/6b7f8af3-70a2-45ec-8eac-f823e196c8b8)
![2](https://github.com/user-attachments/assets/7b1e6a3a-b0ea-4c0b-a827-35dadd7765f9)

