### PR TITLE
Feature/#255: 전역 NotFound 페이지 추가

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,24 @@
+import Link from 'next/link';
+
+const NotFound = () => {
+  return (
+    <div className="text-write-main flex-center absolute top-0 left-0 h-screen w-screen flex-col gap-36 bg-white">
+      <div className="text-write-sub-title flex flex-col items-center gap-6 md:gap-14">
+        <p className="text-write-sub-title text-8xl font-black md:text-9xl">
+          404
+        </p>
+        <h1 className="text-3xl font-semibold md:text-4xl">
+          페이지를 찾을 수 없습니다
+        </h1>
+      </div>
+      <Link
+        href="/"
+        className="pointer border-write-sub-title text-write-sub-title rounded-full border-2 px-6 py-3 font-bold"
+      >
+        홈 페이지로 이동
+      </Link>
+    </div>
+  );
+};
+
+export default NotFound;


### PR DESCRIPTION
## 변경 사항
올바르지 않은 URL로 접근했을 때, 보여지는 `not-found`페이지를 만들었습니다.
각 컴포넌트 및 함수 내부에서
```
import { notFound } from 'next/navigation';

if (!data) notFound() 
```
와 같이 `notFound()` 를 호출할 경우에도 해당 페이지로 연결됩니다.
서버 컴포넌트에서도 정상적으로 동작하기 때문에 필요한 에러처리에 사용해주시면 될 것 같습니다.

## 구현결과(사진첨부 선택)

![pc뷰포트](https://github.com/user-attachments/assets/7339ea5b-bb7d-48f4-afeb-abb9f04b38fc)
![모바일 뷰포트](https://github.com/user-attachments/assets/24409de1-c056-4011-9ce0-a7784e713e8a)
