### PR TITLE
Refactor/#261: default layout 설정 추가 및 수정

### DIFF
--- a/src/app/library/detail/[id]/page.tsx
+++ b/src/app/library/detail/[id]/page.tsx
@@ -73,7 +73,7 @@ const StoryDetail = () => {
   if (!story) return null;
 
   return (
-    <div className="absolute top-0 left-0 h-screen w-screen bg-white">
+    <div className="h-screen w-screen bg-white">
       <div className="flex-center relative h-full w-full flex-col">
         {storyPageNumber === 0 ? (
           <>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 
 const NotFound = () => {
   return (
-    <div className="text-write-main flex-center absolute top-0 left-0 h-screen w-screen flex-col gap-36 bg-white">
+    <div className="text-write-main flex-center h-screen w-screen flex-col gap-36 bg-white">
       <div className="text-write-sub-title flex flex-col items-center gap-6 md:gap-14">
         <p className="text-write-sub-title text-8xl font-black md:text-9xl">
           404

--- a/src/app/social/detail/[socialId]/_components/SocialOverView.tsx
+++ b/src/app/social/detail/[socialId]/_components/SocialOverView.tsx
@@ -111,7 +111,7 @@ const SocialOverView = ({
   });
 
   return (
-    <div className="flex h-83 w-full flex-col justify-center gap-5 sm:flex-row">
+    <div className="flex w-full flex-col justify-center gap-5 sm:flex-row">
       <Image
         src={socialDetailData.image}
         alt=""

--- a/src/components/layout/LayoutWrapper.tsx
+++ b/src/components/layout/LayoutWrapper.tsx
@@ -1,18 +1,43 @@
 'use client';
 
 import { usePathname } from 'next/navigation';
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, useMemo } from 'react';
 
 const LayoutWrapper = ({ children }: PropsWithChildren) => {
   const pathname = usePathname();
-  const isAuths = pathname.startsWith('/auths');
-  const basicStyle = 'mx-auto w-full max-w-300 px-4 pt-20 min-h-lvh h-full';
+
+  const layoutStyle = useMemo(() => {
+    if (pathname.startsWith('/auths')) {
+      return {
+        outer: 'bg-gray-100',
+        inner: 'w-full',
+      };
+    }
+
+    if (
+      pathname === '/library' ||
+      pathname.startsWith('/social') ||
+      pathname.startsWith('/mypage')
+    ) {
+      return {
+        outer: 'bg-gray-100',
+        inner:
+          'bg-gray-50 mx-auto w-full max-w-300 px-4 pt-20 min-h-lvh h-full',
+      };
+    }
+
+    // default layout
+    return {
+      outer: 'bg-white',
+      inner: 'w-full',
+    };
+  }, [pathname]);
+
   return (
-    <div className="h-full flex-1 bg-gray-100">
-      <div className={`${basicStyle} ${isAuths ? null : 'bg-gray-50'}`}>
-        {children}
-      </div>
+    <div className={`h-full flex-1 ${layoutStyle.outer}`}>
+      <div className={layoutStyle.inner}>{children}</div>
     </div>
   );
 };
+
 export default LayoutWrapper;

--- a/src/components/layout/LayoutWrapper.tsx
+++ b/src/components/layout/LayoutWrapper.tsx
@@ -26,7 +26,7 @@ const LayoutWrapper = ({ children }: PropsWithChildren) => {
       };
     }
 
-    // default layout
+    // default layout (/library/detail, /not-found)
     return {
       outer: 'bg-white',
       inner: 'w-full',


### PR DESCRIPTION
## 변경 사항
기존에는 /auths  경로만 스타일을 다르게 하고 나머지 경로에는 똑같은 스타일을 주었는데 이번에 not-found 페이지와 /library/detail 페이지에 다른 스타일이 적용된 걸 확인하여 설정을 추가했습니다.

## 구현결과(사진첨부 선택)
[not-found, library/detail]
![404](https://github.com/user-attachments/assets/8c051abf-11fd-4d80-89a5-14287c995b29)
![detail](https://github.com/user-attachments/assets/cf8a9289-a203-4e5d-ab9b-73108e34aa3b)

[social, library, mypage]
![library](https://github.com/user-attachments/assets/618912d2-accd-4f7b-9137-f5cd406be842)

[auths]
![auths](https://github.com/user-attachments/assets/f94d40cf-81a4-49d7-97f1-c32f5e67cf13)
