### PR TITLE
refactor: 모임과 스토리의 개념을 명확하게 구분하기 위해 UI 수정

### DIFF
--- a/src/app/social/_components/CreateSocialModalButton.tsx
+++ b/src/app/social/_components/CreateSocialModalButton.tsx
@@ -22,9 +22,8 @@ const CreateSocialModalButton = () => {
   return (
     <>
       {/* 모임만들기 버튼 */}
-      {/* 버튼사이즈는 버튼 리팩토링 이후 삭제예정 */}
-      <Button size="custom" className="w-[115px]" onClick={handleModalClick}>
-        모임만들기
+      <Button size="custom" className="px-3" onClick={handleModalClick}>
+        스토리그룹 만들기
       </Button>
 
       <Modal

--- a/src/app/social/_components/CreateSocialModalButton.tsx
+++ b/src/app/social/_components/CreateSocialModalButton.tsx
@@ -22,7 +22,7 @@ const CreateSocialModalButton = () => {
   return (
     <>
       {/* 모임만들기 버튼 */}
-      <Button size="custom" className="px-3" onClick={handleModalClick}>
+      <Button size="custom" className="px-4" onClick={handleModalClick}>
         스토리그룹 만들기
       </Button>
 

--- a/src/app/social/page.tsx
+++ b/src/app/social/page.tsx
@@ -17,16 +17,16 @@ const Social = async () => {
     <HydrationBoundary state={dehydrate(queryClient)}>
       <div className="flex flex-col justify-center gap-5 px-3 py-8 md:px-7">
         <h1 className="text-xl leading-tight font-medium text-gray-900 md:text-[1.5rem]">
-          다른 사람들과 함께 만들어가는
+          모두와 만들어 나가는 상상의 여정
           <span className="text-write-sub-title mt-1 block text-[2.4rem] font-extrabold">
-            특별한 이야기
+            함께 쓰고, 함께 완성하는 이야기
             <span className="text-write-sub-title ml-2 inline-block pt-1.5 align-top">
               <BookOpen className="h-6.5 w-6.5" aria-hidden="true" />
             </span>
           </span>
         </h1>
         <p className="text-lg font-medium text-gray-400 md:text-lg">
-          당신의 상상력으로 이야기를 완성해보세요
+          지금, 당신의 상상을 더해보세요
         </p>
       </div>
       <SocialListContainer />

--- a/src/components/layout/GNB/MenuGroups.tsx
+++ b/src/components/layout/GNB/MenuGroups.tsx
@@ -1,32 +1,43 @@
 import { APP_ROUTES, APP_ROUTES_LABEL } from '@/constants/appRoutes';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-
-// 메뉴 항목
-const MENU_ITEMS = [
-  { label: APP_ROUTES_LABEL.social, href: APP_ROUTES.social },
-  { label: APP_ROUTES_LABEL.library, href: APP_ROUTES.library },
-];
+import { Users, BookOpen } from 'lucide-react';
 
 const MenuGroups = () => {
   const pathname = usePathname();
 
   return (
     <ul className="hidden gap-6 font-semibold md:flex">
-      {MENU_ITEMS.map(({ label, href }) => {
-        const isActive = pathname === href;
-
-        return (
-          <li
-            key={href}
-            className={`${
-              isActive ? 'text-write-main bg-gray-100' : 'text-gray-500'
-            } hover:text-write-main rounded-xl px-2 py-1.5 hover:bg-gray-100`}
-          >
-            <Link href={href}>{label}</Link>
-          </li>
-        );
-      })}
+      <li
+        className={`${
+          pathname === '/social'
+            ? 'text-write-main bg-gray-100'
+            : 'text-gray-500'
+        } hover:text-write-main inline-flex rounded-xl px-3 py-1.5 hover:bg-gray-100`}
+      >
+        <Link
+          href={APP_ROUTES.social}
+          className="inline-flex items-center gap-1.5"
+        >
+          <Users className="h-5 w-5" aria-hidden="true" />
+          {APP_ROUTES_LABEL.social}
+        </Link>
+      </li>
+      <li
+        className={`${
+          pathname === '/library'
+            ? 'text-write-main bg-gray-100'
+            : 'text-gray-500'
+        } hover:text-write-main inline-flex rounded-xl px-2 py-1.5 hover:bg-gray-100`}
+      >
+        <Link
+          href={APP_ROUTES.library}
+          className="inline-flex items-center gap-1.5"
+        >
+          <BookOpen className="h-5 w-5" aria-hidden="true" />
+          {APP_ROUTES_LABEL.library}
+        </Link>
+      </li>
     </ul>
   );
 };

--- a/src/constants/appRoutes.ts
+++ b/src/constants/appRoutes.ts
@@ -11,8 +11,8 @@ export const APP_ROUTES = {
 
 export const APP_ROUTES_LABEL = {
   home: '메인으로',
-  social: '모임찾기',
-  library: '스토리 찾기',
+  social: '스토리그룹',
+  library: '공개된 스토리',
   mypage: '마이페이지',
   signin: '로그인',
   signup: '회원가입',


### PR DESCRIPTION
## 변경 사항

- GNB 네비게이션 메뉴 아이템에 svg 적용
- 모임찾기 -> `스토리그룹`, 스토리찾기 -> `공개된 스토리`로 페이지명 변경 
(모임이라는 용어를 제거하고, 스토리라는 하나의 용어만 남도록 하였습니다.)
- `/social` 페이지 타이틀 배너 문구 수정

Figma 시안이 존재하지 않기도 하고, 용어나 배너 문장도 팀원들간의 의견이 갈릴 수 있는 부분이라서
일단은 최대한 기본적인 `GNB`와 메인 페이지(`/social`) UI를 변경하였습니다.

피드백을 반영한 후에 최종 확정되면 그때 확정된 용어로 프로젝트 내의 모든 부분을 수정하겠습니다.

## 구현결과(사진첨부 선택)
(비교 사진만 보는 것보단 브랜치 pull 하신 다음에 개발 환경에서 직접 확인해보시는걸 추천드립니다!)
### Before
![용어 리뉴얼 전](https://github.com/user-attachments/assets/74f39458-3556-41cf-90d0-2f0af74d2d26)



### After
![용어 리뉴얼 후](https://github.com/user-attachments/assets/5eaaaaad-5df6-43a1-be69-5fff8802aeb1)


