### PR TITLE
Refactor/# mypage noImage 처리, alert를 toast로 대체

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -26,6 +26,7 @@ const nextConfig: NextConfig = {
       'inabooth.io',
       'd19bi7owzxc0m2.cloudfront.net',
       'vrxqxfmkfmhihinihubf.supabase.co',
+      'placehold.co',
     ],
   },
 };

--- a/src/api/mypage/api.ts
+++ b/src/api/mypage/api.ts
@@ -7,6 +7,8 @@ import {
 import instance from '@/api/instance';
 import { getFilterParams } from '@/utils/getFilterParams';
 import instanceBaaS from '@/api/instanceBaaS';
+import { getCookie } from '@/api/cookies';
+import toast from '@/utils/toast';
 
 export const getJoinedSocialList = async ({
   limit = 12,
@@ -62,10 +64,23 @@ export const deleteCollaboratorFromSocial = async (
 };
 
 export const leaveJoinSocial = async ({ id }: LeaveJoinSocialRequest) => {
+  const accessToken = await getCookie('accessToken');
+  if (!accessToken) {
+    throw new Error('accessToken이 없습니다.');
+  }
   try {
-    const response = await instance.delete(API_PATH.SOCIAL + `/${id}/leave`);
+    const response = await instance.delete(API_PATH.SOCIAL + `/${id}/leave`, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
     return response.data;
   } catch (error) {
+    toast({
+      type: 'error',
+      message: '모임 나가기에 실패하였습니다.',
+      duration: 5,
+    });
     throw error;
   }
 };

--- a/src/app/mypage/_components/my-social-list/MySocialListCardItem.tsx
+++ b/src/app/mypage/_components/my-social-list/MySocialListCardItem.tsx
@@ -13,6 +13,7 @@ import { useRouter } from 'next/navigation';
 import getSocialActionMessage from '@/utils/getSocialActionMessage';
 import { useStoryIdBySocialId } from '@/hooks/api/supabase/useStoryIdBySocialId';
 import toast from '@/utils/toast';
+import { APP_ROUTES } from '@/constants/appRoutes';
 
 const MySocialListCardItem = ({
   item,
@@ -35,14 +36,16 @@ const MySocialListCardItem = ({
 
   const handleMySocial = async (id: string) => {
     if (!storyId) return;
+
     const messages = {
       confirm: getSocialActionMessage('모임').confirm('exit'),
       success: getSocialActionMessage('모임').success('exit'),
-      fail: getSocialActionMessage('모임').fail('exit'),
     };
+
     if (isJoined) {
       const confirmed = window.confirm(messages.confirm);
       if (!confirmed) return;
+
       if (userId) {
         await leaveJoinSocial({ id });
         await deleteCollaboratorFromSocial(userId, storyId);
@@ -50,7 +53,7 @@ const MySocialListCardItem = ({
         refetch();
       }
     } else {
-      router.push(`/library/detail/${storyId}/?page=0`);
+      router.push(`${APP_ROUTES.libraryDetail}/${storyId}/?page=0`);
     }
   };
 
@@ -60,7 +63,7 @@ const MySocialListCardItem = ({
         teamUserRole={activeTab === 'created' ? 'LEADER' : 'MEMBER'}
         pageId={storyId}
         image={{
-          src: '',
+          src: item.image,
           alt: item.name || '섬네일 이미지',
         }}
         chip

--- a/src/app/mypage/_components/my-social-list/MySocialListCardItem.tsx
+++ b/src/app/mypage/_components/my-social-list/MySocialListCardItem.tsx
@@ -13,7 +13,6 @@ import { useRouter } from 'next/navigation';
 import getSocialActionMessage from '@/utils/getSocialActionMessage';
 import { useStoryIdBySocialId } from '@/hooks/api/supabase/useStoryIdBySocialId';
 import toast from '@/utils/toast';
-import { IMAGE_ROUTES } from '@/constants/ImageRoutes';
 
 const MySocialListCardItem = ({
   item,
@@ -61,7 +60,7 @@ const MySocialListCardItem = ({
         teamUserRole={activeTab === 'created' ? 'LEADER' : 'MEMBER'}
         pageId={storyId}
         image={{
-          src: item.image || IMAGE_ROUTES.noImage,
+          src: '',
           alt: item.name || '섬네일 이미지',
         }}
         chip

--- a/src/app/mypage/_components/my-social-list/MySocialListCardItem.tsx
+++ b/src/app/mypage/_components/my-social-list/MySocialListCardItem.tsx
@@ -12,6 +12,8 @@ import convertLocationToGenre from '@/utils/convertLocationToGenre';
 import { useRouter } from 'next/navigation';
 import getSocialActionMessage from '@/utils/getSocialActionMessage';
 import { useStoryIdBySocialId } from '@/hooks/api/supabase/useStoryIdBySocialId';
+import toast from '@/utils/toast';
+import { IMAGE_ROUTES } from '@/constants/ImageRoutes';
 
 const MySocialListCardItem = ({
   item,
@@ -34,28 +36,22 @@ const MySocialListCardItem = ({
 
   const handleMySocial = async (id: string) => {
     if (!storyId) return;
-
-    try {
-      const messages = {
-        confirm: getSocialActionMessage('모임').confirm('exit'),
-        success: getSocialActionMessage('모임').success('exit'),
-      };
-
-      if (isJoined) {
-        const confirmed = window.confirm(messages.confirm);
-        if (!confirmed) return;
+    const messages = {
+      confirm: getSocialActionMessage('모임').confirm('exit'),
+      success: getSocialActionMessage('모임').success('exit'),
+      fail: getSocialActionMessage('모임').fail('exit'),
+    };
+    if (isJoined) {
+      const confirmed = window.confirm(messages.confirm);
+      if (!confirmed) return;
+      if (userId) {
         await leaveJoinSocial({ id });
-        if (userId) {
-          await deleteCollaboratorFromSocial(userId, storyId);
-          alert(messages.success);
-          refetch();
-        }
-      } else {
-        router.push(`/library/detail/${storyId}/?page=0`);
+        await deleteCollaboratorFromSocial(userId, storyId);
+        toast.success(messages.success);
+        refetch();
       }
-    } catch (error) {
-      console.error(error);
-      alert('모임 취소에 실패했습니다.');
+    } else {
+      router.push(`/library/detail/${storyId}/?page=0`);
     }
   };
 
@@ -65,9 +61,7 @@ const MySocialListCardItem = ({
         teamUserRole={activeTab === 'created' ? 'LEADER' : 'MEMBER'}
         pageId={storyId}
         image={{
-          src:
-            item.image ||
-            'https://inabooth.io/_next/image?url=https%3A%2F%2Fd19bi7owzxc0m2.cloudfront.net%2Fprod%2Fcharacter_files%2FRwH7fLwSHwA4_e2s354f2.webp&w=3840&q=75',
+          src: item.image || IMAGE_ROUTES.noImage,
           alt: item.name || '섬네일 이미지',
         }}
         chip

--- a/src/components/common/Card/ListCard.tsx
+++ b/src/components/common/Card/ListCard.tsx
@@ -41,10 +41,10 @@ const ListCard = ({
         </div>
       )}
       <figure className="relative h-48 w-full max-w-50 flex-shrink-0 sm:h-39 sm:w-70">
-        {!isImageLoaded || isImageLoadError || isCardDataLoading ? (
+        {!!isImageLoaded || isImageLoadError || isCardDataLoading ? (
           <div className="absolute h-full w-full animate-pulse rounded-xl bg-gray-300" />
         ) : null}
-        {image.src && image.alt && !isCardDataLoading && (
+        {image.src && image.alt && !isCardDataLoading ? (
           <Image
             src={image.src}
             alt={image.alt ? image.alt : '이미지를 불러올 수 없습니다'}
@@ -53,6 +53,10 @@ const ListCard = ({
             fill
             className={`rounded-3xl object-cover ${isImageLoaded ? 'opacity-100' : 'opacity-0'}`}
           />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center rounded-3xl bg-gray-400 text-base text-white">
+            No Image
+          </div>
         )}
       </figure>
       <div className="flex w-full flex-col gap-3 px-1.5 sm:p-0">

--- a/src/constants/ImageRoutes.ts
+++ b/src/constants/ImageRoutes.ts
@@ -1,0 +1,4 @@
+export const IMAGE_ROUTES = {
+  noImage:
+    'https://placehold.co/300x200/cccccc/ffffff.png?text=No+Image&font=roboto&format=png',
+};

--- a/src/constants/ImageRoutes.ts
+++ b/src/constants/ImageRoutes.ts
@@ -1,4 +1,0 @@
-export const IMAGE_ROUTES = {
-  noImage:
-    'https://placehold.co/300x200/cccccc/ffffff.png?text=No+Image&font=roboto&format=png',
-};

--- a/src/hooks/api/auth/useUpdateMyInfo.ts
+++ b/src/hooks/api/auth/useUpdateMyInfo.ts
@@ -5,6 +5,7 @@ import { updateMyInfo } from '@/api/auth/api';
 import { MyInfoRequest } from '@/api/auth/type';
 import { QUERY_KEY } from '@/constants/queryKey';
 import { useRouter } from 'next/navigation';
+import toast from '@/utils/toast';
 
 export const useUpdateMyInfo = () => {
   // const queryClient = useQueryClient();
@@ -14,8 +15,16 @@ export const useUpdateMyInfo = () => {
     mutationKey: [QUERY_KEY.MY_INFO],
     mutationFn: (data: MyInfoRequest) => updateMyInfo(data),
     onSuccess: () => {
+      toast.success('프로필이 수정되었습니다.');
       router.refresh();
       // queryClient.invalidateQueries({ queryKey: [QUERY_KEY.MY_INFO] });
+    },
+    onError: () => {
+      toast({
+        type: 'error',
+        message: '오류가 발생하여 프로필 수정에 실패하였습니다.',
+        duration: 5,
+      });
     },
   });
 };


### PR DESCRIPTION
## 변경 사항
- 섬네일 이미지 없을 경우 대체 이미지를 변경
- 기존에 alert를 썻던걸 toast로 대체
- 모임 나가기시 token이 필요한 부분이 있어 수정

## 구현결과(사진첨부 선택)
[noImage - div로 변경]
![image](https://github.com/user-attachments/assets/bb184fe5-19cd-4444-9c5a-eb59e5aaad36)
[toast]
![image](https://github.com/user-attachments/assets/273bc6c5-5765-47ba-9d42-e8af0603140f)
