### PR TITLE
Refactor/#282: 컨텐츠 및 페이지네이션의 반응형 레이아웃 상세화 및 더 정확하게 DOM 렌더링 높이를 측정하도록 개선

### DIFF
--- a/src/app/library/detail/[id]/_components/PaginatedContentViewer.tsx
+++ b/src/app/library/detail/[id]/_components/PaginatedContentViewer.tsx
@@ -20,7 +20,7 @@ const PaginatedContentViewer = forwardRef(
 
           return (
             <p
-              className="mb-4 w-80 text-center text-[1.05rem] leading-[2] break-words md:flex md:w-160 md:flex-wrap md:justify-between md:space-x-4 md:text-left md:text-lg md:leading-[2.4]"
+              className="mb-4 w-80 text-center text-[1.05rem] leading-[2] break-words md:flex md:w-160 md:flex-wrap md:justify-between md:space-x-4 md:text-left md:text-lg md:leading-[2.5]"
               key={index}
             >
               {isHtmlContent

--- a/src/app/library/detail/[id]/_components/PaginatedContentViewer.tsx
+++ b/src/app/library/detail/[id]/_components/PaginatedContentViewer.tsx
@@ -20,7 +20,7 @@ const PaginatedContentViewer = forwardRef(
 
           return (
             <p
-              className="mb-4 w-80 text-center text-[1.05rem] leading-[2] break-words md:flex md:w-160 md:flex-wrap md:justify-between md:space-x-4 md:text-left md:text-lg md:leading-[2.5]"
+              className="mb-4 w-80 text-center text-[1.05rem] leading-[2] break-words md:flex md:w-160 md:flex-wrap md:justify-between md:space-x-4 md:text-left md:text-lg md:leading-[2.4]"
               key={index}
             >
               {isHtmlContent

--- a/src/app/library/detail/[id]/_components/PaginationControl.tsx
+++ b/src/app/library/detail/[id]/_components/PaginationControl.tsx
@@ -24,7 +24,7 @@ export const PaginationControl = ({
 
   return (
     <nav
-      className="fixed bottom-5 flex flex-col items-center justify-center gap-1.5 md:gap-4"
+      className="fixed bottom-5 flex flex-col items-center justify-center gap-1.5 md:gap-3"
       aria-label="페이지 이동 네비게이션"
     >
       <span

--- a/src/app/library/detail/[id]/hooks/usePaginateContentsByViewport.ts
+++ b/src/app/library/detail/[id]/hooks/usePaginateContentsByViewport.ts
@@ -56,7 +56,7 @@ const usePaginateContentsByViewport = ({
       const paragraph = document.createElement('div');
       paragraph.innerHTML = html;
       paragraph.className =
-        'text-[1.05rem] md:text-lg leading-[1.9] md:leading-[2.4] mb-4 break-words w-80';
+        'text-[1.05rem] md:text-lg leading-[2] md:leading-[2.5] mb-4 break-words w-80';
 
       tempContainer.appendChild(paragraph);
       const paragraphHeight = paragraph.getBoundingClientRect().height;

--- a/src/app/library/detail/[id]/hooks/usePaginateContentsByViewport.ts
+++ b/src/app/library/detail/[id]/hooks/usePaginateContentsByViewport.ts
@@ -55,7 +55,8 @@ const usePaginateContentsByViewport = ({
     currentContents.forEach((html) => {
       const paragraph = document.createElement('div');
       paragraph.innerHTML = html;
-      paragraph.className = 'text-lg leading-[2] md:leading-[2.5] mb-4';
+      paragraph.className =
+        'text-[1.05rem] md:text-lg leading-[1.9] md:leading-[2.4] mb-4 break-words w-80';
 
       tempContainer.appendChild(paragraph);
       const paragraphHeight = paragraph.getBoundingClientRect().height;


### PR DESCRIPTION
## 변경 사항

특정 뷰포트 및 화면 비율에서 컨텐츠와 페이지네이션이 겹쳐 보이는 문제를 수정했습니다.
(특정 조건에서만 발생하는 문제이기도 하고, 최종 발표 전까지 병합하기 어려울 수 있을 것 같아서 hotfix 브랜치로
분류하지는 않았습니다)

1. 모든 뷰포트에서 줄간 간격을 소폭 줄였습니다. (`leading` 클래스)
2. 페이지 이동 네비게이션에서 타이틀과 네비게이션 버튼 사이의 간격을 1rem 줄였습니다.
3. 렌더링된 DOM이 컨텐츠의 높이를 더 정확하게 측정할 수 있도록 상세한 스타일을 적용하였습니다.


### before
DOM이 컨텐츠의 높이를 정확하게 측정하지 못해서 한 페이지 내부에 많은 컨텐츠가 출력
![6 23 레이아웃 개선1](https://github.com/user-attachments/assets/d32d5c67-f366-4602-8689-cd7bec39a33b)


### after
컨텐츠의 높이를 보다 정확하게 측정하여 두 페이지로 나눠서 컨텐츠 출력
![6 23 레이아웃 개선2](https://github.com/user-attachments/assets/cd713d0e-1c5b-4ba3-8ec1-6d2a9c990e1b)



