### PR TITLE
fix: 마이페이지에서 탈퇴하기 버그 수정

### DIFF
--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -20,11 +20,12 @@ instance.interceptors.request.use(async (config) => {
 
   const fullUrl = new URL(config.url || '', config.baseURL || '');
   const path = fullUrl.pathname;
+
   const isExcluded = excludedPaths.some((rule) =>
     rule instanceof RegExp ? rule.test(path) : rule === path
   );
 
-  if (isExcluded) {
+  if (isExcluded && !path.endsWith('/leave')) {
     return config;
   }
 


### PR DESCRIPTION
## 변경 사항
- 마이페이지에서 모임 나가기가 안되는 버그 수정했습니다.(https://www.notion.so/21b78ea740348084a264c4484d273245?source=copy_link)
- gathering+정규식에 걸려서 안된걸로 판단했습니다. 
- 정규식 수정하면 다른 곳에도 문제가 생길 것 같아 leave 경로만 따로 if문으로 임시방편으로 처리했습니다.
## 구현결과(사진첨부 선택)

(내용)
