### PR TITLE
Fix/#286: 만료된 토큰 처리 방식 변경

### DIFF
--- a/src/api/cookies.ts
+++ b/src/api/cookies.ts
@@ -5,7 +5,7 @@ export const setCookie = async (key: string, value: string) => {
   cookieStore.set(key, value, {
     httpOnly: true,
     secure: true,
-    maxAge: 60 * 60 * 24 * 30,
+    maxAge: 60 * 60,
     path: '/',
   });
 };

--- a/src/hooks/api/auth/useGetMyInfo.ts
+++ b/src/hooks/api/auth/useGetMyInfo.ts
@@ -5,12 +5,10 @@ import { QUERY_KEY } from '@/constants/queryKey';
 import { useQuery } from '@tanstack/react-query';
 import handleError from '@/utils/error';
 import toast from '@/utils/toast';
-import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
+import { deleteCookie } from '@/api/cookies';
 
 export const useGetMyInfo = (accessToken: string) => {
-  const router = useRouter();
-
   const query = useQuery({
     queryKey: [QUERY_KEY.MY_INFO],
     queryFn: () => getMyInfo(accessToken),
@@ -23,12 +21,12 @@ export const useGetMyInfo = (accessToken: string) => {
         onStatus: (status) => {
           if (status === 401) {
             toast.error('로그인 정보가 만료되었습니다. 다시 로그인해주세요.');
-            router.push('/auths/signin');
+            deleteCookie('accessToken');
           }
         },
       });
     }
-  }, [query.error, router]);
+  }, [query.error]);
 
   return query;
 };


### PR DESCRIPTION
## 변경 사항

### 1. `setCookie` maxAge 수정 (`cookies.ts`)
- 기존: `maxAge: 60 * 60 * 24 * 30` (30일)
- 변경: `maxAge: 60 * 60` (1시간)
- **변경 목적**: 토큰의 유효기간을 1시간으로 단축하여 보안 강화 및 자동 로그아웃 시나리오 대응

---

### 2. `useGetMyInfo` 훅 개선 (`useGetMyInfo.ts`)
- `useRouter` 및 `router.push()` 제거
- 401 응답 시 처리 방식 변경:
  - 에러 토스트 메시지 출력: `"로그인 정보가 만료되었습니다. 다시 로그인해주세요."`
  - `accessToken` 쿠키 삭제: `deleteCookie('accessToken')`
- **변경 목적**: 인증 만료 시 클라이언트 라우팅에 의존하지 않고 쿠키 정리만 수행하도록 단순화

---

## 구현 결과 (사진 첨부 선택)

- 사용자 토큰 만료 시:
  - 로그인 만료 안내 토스트 출력
  - `accessToken` 쿠키 삭제
  - 라우팅은 상위 레벨에서 제어할 수 있도록 책임 분리됨