### PR TITLE
Fix/#284 : 소셜상세페이지에서 api로 모임참여 임시로 추가

### DIFF
--- a/src/api/social-detail/api.ts
+++ b/src/api/social-detail/api.ts
@@ -14,6 +14,7 @@ import instanceBaaS from '../instanceBaaS';
 import { AxiosError } from 'axios';
 import instance from '@/api/instance';
 import { API_PATH } from '@/constants/apiPath';
+import { getCookie } from '@/api/cookies';
 
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
 
@@ -169,6 +170,41 @@ export const getStoryId = async ({
     return 'not-found';
   }
   return data;
+};
+
+export const getSocialId = async (storyId: string) => {
+  const { data, error } = await instanceBaaS
+    .from('Stories')
+    .select('social_id')
+    .eq('story_id', storyId)
+    .maybeSingle();
+
+  if (error) throw new Error(error.message);
+  if (!data) {
+    return 'not-found';
+  }
+  return data.social_id;
+};
+
+export const joinTeam = async (socialId: string) => {
+  const accessToken = await getCookie('accessToken');
+  if (!accessToken) {
+    throw new Error('accessToken이 없습니다.');
+  }
+  const res = await instance.post(
+    `${API_PATH.SOCIAL}/${socialId}/join`,
+    { socialId },
+    {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+        Authorization: `Bearer ${accessToken}`,
+      },
+    }
+  );
+  if (res.status === 201) {
+    return res.data;
+  }
+  throw new Error('모임 가입 실패!');
 };
 
 export const deleteSocialByDb = async ({ storyId }: DeleteSocialByDbParams) => {

--- a/src/app/social/detail/[storyId]/hooks/useSocialActions.ts
+++ b/src/app/social/detail/[storyId]/hooks/useSocialActions.ts
@@ -1,3 +1,4 @@
+import { getSocialId, joinTeam } from '@/api/social-detail/api';
 import { UseSocialActionsParams } from '@/app/social/detail/[storyId]/type';
 import { APP_ROUTES } from '@/constants/appRoutes';
 import useParticipateCollaborator from '@/hooks/api/supabase/story-collaborators/useParticipateCollaborator';
@@ -29,11 +30,13 @@ const useSocialActions = ({
     router.push(`${APP_ROUTES.signin}`);
   };
 
-  const joinSocial = () => {
+  const joinSocial = async () => {
     const joinTeamConfirmed = window.confirm('모임에 참여하시겠습니까?');
     if (!joinTeamConfirmed) return;
 
-    insertNewCollaborator({
+    const socialId = await getSocialId(storyId);
+    await joinTeam(socialId);
+    await insertNewCollaborator({
       data: {
         story_id: storyId,
         user_id: userId!,
@@ -44,10 +47,10 @@ const useSocialActions = ({
     });
   };
 
-  const navigateStoryOrJoinSocial = (role: TeamUserRole) => {
+  const navigateStoryOrJoinSocial = async (role: TeamUserRole) => {
     if (!userId || !userName) return navigateLogin();
 
-    if (role === 'GUEST') return joinSocial();
+    if (role === 'GUEST') return await joinSocial();
 
     return navigateStoryDetail();
   };


### PR DESCRIPTION
## 변경 사항
현재 마이페이지는 달램 API를 사용중이여서 내일 발표에 정상작동하게 위해 상세페이지에 임시로 달램 API를 적용하는 코드를 추가하였습니다.

## 구현결과(사진첨부 선택)
![image](https://github.com/user-attachments/assets/5a7a199b-ef2d-4faa-ab01-2890382b945d)
