### PR TITLE
Hotfix/#285 중복으로 컨텐츠가 등록되는 문제 수정

### DIFF
--- a/src/api/stories/api.ts
+++ b/src/api/stories/api.ts
@@ -80,7 +80,7 @@ export const getLastContent = async (
     .eq('story_id', id)
     .order('merged_at', { ascending: false })
     .limit(1)
-    .single();
+    .maybeSingle();
   if (error) {
     throw new Error(error.message);
   }

--- a/src/app/library/detail/[id]/_components/StoryModalTriggerButton.tsx
+++ b/src/app/library/detail/[id]/_components/StoryModalTriggerButton.tsx
@@ -1,11 +1,22 @@
+import { QUERY_KEY } from '@/constants/queryKey';
+import { getQueryClient } from '@/lib/queryClinet';
 import { useStoryModal } from '@/providers/StoryWriteOrApproveModalProviders';
 import { ContentWriteIcon } from '@public/assets/icons';
 
-const StoryModalTriggerButton = () => {
+const StoryModalTriggerButton = ({ storyId }: { storyId: string }) => {
   const { openModal } = useStoryModal();
+  const queryClient = getQueryClient();
+
+  const handleOpenModal = () => {
+    queryClient.invalidateQueries({
+      queryKey: [QUERY_KEY.GET_LAST_CONTENT, storyId],
+    });
+    openModal();
+  };
+
   return (
     <button
-      onClick={openModal}
+      onClick={handleOpenModal}
       className="fixed right-6 bottom-10 h-15 w-15 md:right-22 md:bottom-14"
     >
       <ContentWriteIcon aria-hidden="true" />

--- a/src/app/library/detail/[id]/_components/WritableUserModal.tsx
+++ b/src/app/library/detail/[id]/_components/WritableUserModal.tsx
@@ -54,9 +54,6 @@ const WritableUserModal = ({
       <CreateStoryContentModal
         currentStoryId={currentStoryId}
         currentUserId={currentUserId}
-        {...(lastContentData && {
-          lastContentData: lastContentData,
-        })}
         maxContentLength={maxContentLength}
       />
     );

--- a/src/app/library/detail/[id]/page.tsx
+++ b/src/app/library/detail/[id]/page.tsx
@@ -54,7 +54,7 @@ const StoryDetail = () => {
       case 'MEMBER':
         return (
           <>
-            <StoryModalTriggerButton />
+            <StoryModalTriggerButton storyId={storyId} />
             <WritableUserModal
               currentStoryId={storyId}
               {...(myInfo && { currentUserId: myInfo.id })}

--- a/src/app/library/detail/[id]/type.ts
+++ b/src/app/library/detail/[id]/type.ts
@@ -1,5 +1,3 @@
-import { DBContentResponse } from '@/types/dbStory';
-
 export interface WritableUserModalProps {
   currentStoryId: string;
   currentUserNickName?: string;
@@ -12,7 +10,6 @@ export interface WritableUserModalProps {
 export interface CreateContentModalProps {
   currentStoryId: string;
   currentUserId?: number;
-  lastContentData?: DBContentResponse;
   maxContentLength: number;
 }
 


### PR DESCRIPTION
## 변경 사항

1. `등록하기` 버튼을 클릭하는 시점에 (마지막 컨텐츠의 status에 대한)최신 정보를 가져와서
만약 `PENDING`상태이면 '등록하시겠습니까?'가 아닌 '승인 대기 중인 글이 존재하여 등록할 수 없습니다.` 메시지가
출력되도록 수정하였습니다.

https://github.com/user-attachments/assets/955c6af6-d004-4262-8ecf-4425773f099c



2. 모달을 여는 시점에 (마지막 컨텐츠의 status에 대한)최신 정보를 가져와서
컨텐츠 작성 UI와 승인 UI 중에 현재 시점에 정확한 UI가 그려지도록 수정하였습니다.


https://github.com/user-attachments/assets/ff702518-d6ac-48d5-864a-13275f0d4953

3. 결과가 존재하지 않을 때 `getLastContent` 함수가 에러를 발생하는 문제를 수정하였습니다. (.single -> .maybeSingle 로 변경)
