### PR TITLE
Fix/#291: 특정 상황에서 GNB의 프로필 이미지가 잘려보이는 현상 수정

### DIFF
--- a/src/components/layout/GNB/LoginSection.tsx
+++ b/src/components/layout/GNB/LoginSection.tsx
@@ -45,7 +45,7 @@ const LoginSection = () => {
               className="aspect-square h-12 w-12 rounded-full border border-gray-300 object-cover"
             />
           ) : (
-            <DefaultProfileImage width={40} height={40} />
+            <DefaultProfileImage width={48} height={48} />
           )}
         </button>
       ) : (

--- a/src/components/layout/GNB/LoginSection.tsx
+++ b/src/components/layout/GNB/LoginSection.tsx
@@ -37,14 +37,13 @@ const LoginSection = () => {
           aria-label="유저 메뉴 열기"
         >
           {myInfo.image ? (
-            <div className="h-10 w-10 overflow-hidden rounded-full bg-gray-300">
-              <Image
-                src={myInfo.image}
-                alt="프로필 이미지"
-                width={40}
-                height={40}
-              />
-            </div>
+            <Image
+              src={myInfo.image}
+              alt="프로필 이미지"
+              width={48}
+              height={48}
+              className="aspect-square h-12 w-12 rounded-full border border-gray-300 object-cover"
+            />
           ) : (
             <DefaultProfileImage width={40} height={40} />
           )}


### PR DESCRIPTION
## 변경 사항

- `<Image>`를 감싸는 `<div>`를 제거하고, `aspect-square` 클래스를 통해 가로 세로 비율을 1:1로 강제하도록 하였습니다.
- 지난 수정 후 프로필 이미지의 가로, 세로 너비가 56 -> 40px로 다소 작게 표시되는 것 같아서 48px로 상향 조정하였습니다.

테스트를 몇 차례 거치긴 했으나 모든 종류의 이미지로 테스트해볼 수가 없어서
혹시 특정 비율의 이미지에서 여전히 잘림 현상 또는 비율이 안맞는 문제가 발생할 수 있습니다.
여러 프로필 이미지가 잘 출력되는 지 테스트해주시면 감사하겠습니다.