### PR TITLE
Fix/#302: SigninForm 테스트 코드 내 필드명 불일치 수정

### DIFF
--- a/src/app/auths/signin/_components/SigninForm.test.tsx
+++ b/src/app/auths/signin/_components/SigninForm.test.tsx
@@ -186,12 +186,12 @@ describe('SignInForm 제출 상태 테스트', () => {
         fn({
           email: 'test@email.com',
           password: 'password123',
-          rememberEmail: true,
+          isRememberEmail: true,
         } as SigninFormData),
       isSubmitting: false,
       errors: {},
-      onSubmit: ({ email, rememberEmail }: SigninFormData) => {
-        if (rememberEmail) {
+      onSubmit: ({ email, isRememberEmail }: SigninFormData) => {
+        if (isRememberEmail) {
           localStorage.setItem('rememberEmail', email);
         }
       },


### PR DESCRIPTION
## 변경 사항

`SigninFormData` 타입 필드명과 테스트 코드 내 사용된 필드명이 불일치해서 에러가 발생하는 문제를 수정했습니다.

[Feature/#67: 로그인 폼 이메일 기억하기 추가](https://github.com/we-write/frontend/pull/186)
해당 PR을 통해 추가된 코드로 보이는데 해당 PR 병합할 당시 및 이후에 빌드 에러로 병합 방지가 동작하지 않은 문제는 확인해봐야 할 것 같습니다.
